### PR TITLE
push base and stage models for education service centers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased 
 ## New features
+- Add models for education service centers
+
 ## Under the hood
 ## Fixes
 

--- a/macros/gen_skey.sql
+++ b/macros/gen_skey.sql
@@ -178,6 +178,11 @@
             'col_list': ['cohortIdentifier', 'educationOrganizationId'],
             'annualize': True
         },
+        'k_service_center': {
+            'reference_name': 'service_center_reference',
+            'col_list': ['educationServiceCenterId'],
+            'annualize': False
+        },
 
         'k_template': {
             'reference_name': '',

--- a/models/staging/edfi_3/base/_edfi_3__base.yml
+++ b/models/staging/edfi_3/base/_edfi_3__base.yml
@@ -46,6 +46,10 @@ models:
   - name: base_ef3__education_organization_networks
     config:
       tags: ['core']
+  - name: base_ef3__education_service_centers
+    config:
+      tags: ['esc']
+      enabled: "{{ var('src:ed_orgs:esc:enabled', True) }}"
   - name: base_ef3__grades
     config:
       tags: ['core']

--- a/models/staging/edfi_3/base/base_ef3__education_service_centers.sql
+++ b/models/staging/edfi_3/base/base_ef3__education_service_centers.sql
@@ -1,0 +1,29 @@
+with service_centers as (
+    {{ source_edfi3('education_service_centers') }}
+),
+renamed as (
+    select 
+        tenant_code,
+        api_year,
+        pull_timestamp,
+        file_row_number,
+        filename,
+        is_deleted,
+        v:id::string                        as record_guid,
+        v:educationServiceCenterId::string  as service_center_id,
+        v:nameOfInstitution::string         as service_center_name,
+        v:shortNameOfInstitution::string    as service_center_short_name,
+        -- descriptors
+        {{ extract_descriptor('v:operationalStatusDescriptor::string') }} as operational_status,
+        -- unflattened lists
+        v:addresses                         as v_addresses,
+        v:categories                        as v_categories,
+        v:identificationCodes               as v_identification_codes,
+        v:indicators                        as v_indicators,
+        v:institutionTelephones             as v_institution_telephones,
+        v:internationalAddresses            as v_international_addresses,
+        -- edfi extensions
+        v:_ext as v_ext
+    from service_centers
+)
+select * from renamed

--- a/models/staging/edfi_3/stage/_edfi_3__stage.yml
+++ b/models/staging/edfi_3/stage/_edfi_3__stage.yml
@@ -269,6 +269,21 @@ models:
     config:
       tags: ['core']
 
+  - name: stg_ef3__education_service_centers
+    config: 
+      tags: ['esc']
+      enabled: "{{ var('src:ed_orgs:esc:enabled', True) }}"
+
+  - name: stg_ef3__education_service_centers__addresses
+    config: 
+      tags: ['esc']
+      enabled: "{{ var('src:ed_orgs:esc:enabled', True) }}"
+
+  - name: stg_ef3__education_service_centers__identification_codes
+    config: 
+      tags: ['esc']
+      enabled: "{{ var('src:ed_orgs:esc:enabled', True) }}"
+
   - name: stg_ef3__grades
     config:
       tags: ['core']

--- a/models/staging/edfi_3/stage/stg_ef3__education_service_centers.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__education_service_centers.sql
@@ -1,0 +1,26 @@
+with base_service_centers as (
+    select * from {{ ref('base_ef3__education_service_centers') }}
+    where not is_deleted
+),
+keyed as(
+    select 
+        {{ dbt_utils.surrogate_key(
+            [
+                'tenant_code',
+                'service_center_id'
+            ]
+        )}} as k_service_center,
+        base_service_centers.*
+        {{ extract_extension(model_name=this.name, flatten=True) }}
+    from base_service_centers
+),
+deduped as (
+    {{
+        dbt_utils.deduplicate(
+            relation='keyed',
+            partition_by='k_service_center',
+            order_by='api_year desc, pull_timestamp desc'
+        )
+    }}
+)
+select * from deduped

--- a/models/staging/edfi_3/stage/stg_ef3__education_service_centers__addresses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__education_service_centers__addresses.sql
@@ -1,0 +1,1 @@
+{{ flatten_addresses('stg_ef3__education_service_centers', ['k_service_center']) }}

--- a/models/staging/edfi_3/stage/stg_ef3__education_service_centers__identification_codes.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__education_service_centers__identification_codes.sql
@@ -1,0 +1,14 @@
+with stg_service_centers as (
+    select * from {{ ref('stg_ef3__education_service_centers') }}
+),
+flattened as (
+    select 
+        tenant_code,
+        api_year,
+        k_service_center,
+        {{ extract_descriptor('value:educationOrganizationIdentificationSystemDescriptor::string') }} as id_system,
+        value:identificationCode::string as id_code
+    from stg_service_centers,
+        lateral flatten(input => v_identification_codes)
+)
+select * from flattened


### PR DESCRIPTION
Adds base and stage models for educationServiceCenters. I used the existing models for educationOrganizationNetworks as a guide. Tested in Boston by checking row counts and validating dedupe.

I haven't added any additional staging models to flatten nested lists. The only one that seems to have helpful data in it (for Boston) is Addresses. Should I add a model to unpack them?