### PR TITLE
Added missed fields; renamed to k_education_service_center

### DIFF
--- a/macros/gen_skey.sql
+++ b/macros/gen_skey.sql
@@ -178,8 +178,8 @@
             'col_list': ['cohortIdentifier', 'educationOrganizationId'],
             'annualize': True
         },
-        'k_service_center': {
-            'reference_name': 'service_center_reference',
+        'k_education_service_center': {
+            'reference_name': 'education_service_center_reference',
             'col_list': ['educationServiceCenterId'],
             'annualize': False
         },

--- a/models/staging/edfi_3/base/base_ef3__education_service_centers.sql
+++ b/models/staging/edfi_3/base/base_ef3__education_service_centers.sql
@@ -9,10 +9,12 @@ renamed as (
         file_row_number,
         filename,
         is_deleted,
-        v:id::string                        as record_guid,
-        v:educationServiceCenterId::string  as service_center_id,
-        v:nameOfInstitution::string         as service_center_name,
-        v:shortNameOfInstitution::string    as service_center_short_name,
+        v:id::string                                            as record_guid,
+        v:educationServiceCenterId::string                      as service_center_id,
+        v:nameOfInstitution::string                             as service_center_name,
+        v:shortNameOfInstitution::string                        as service_center_short_name,
+        v:stateEducationAgencyReference:stateEducationAgencyId  as state_education_agency_id,
+        v:webSite::string                                       as website,
         -- descriptors
         {{ extract_descriptor('v:operationalStatusDescriptor::string') }} as operational_status,
         -- unflattened lists
@@ -22,6 +24,8 @@ renamed as (
         v:indicators                        as v_indicators,
         v:institutionTelephones             as v_institution_telephones,
         v:internationalAddresses            as v_international_addresses,
+        -- references
+        v:stateEducationAgencyReference     as state_education_agency_reference,
         -- edfi extensions
         v:_ext as v_ext
     from service_centers

--- a/models/staging/edfi_3/stage/stg_ef3__education_service_centers.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__education_service_centers.sql
@@ -9,7 +9,7 @@ keyed as(
                 'tenant_code',
                 'service_center_id'
             ]
-        )}} as k_service_center,
+        )}} as k_education_service_center,
         base_service_centers.*
         {{ extract_extension(model_name=this.name, flatten=True) }}
     from base_service_centers
@@ -18,7 +18,7 @@ deduped as (
     {{
         dbt_utils.deduplicate(
             relation='keyed',
-            partition_by='k_service_center',
+            partition_by='k_education_service_center',
             order_by='api_year desc, pull_timestamp desc'
         )
     }}

--- a/models/staging/edfi_3/stage/stg_ef3__education_service_centers__addresses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__education_service_centers__addresses.sql
@@ -1,1 +1,1 @@
-{{ flatten_addresses('stg_ef3__education_service_centers', ['k_service_center']) }}
+{{ flatten_addresses('stg_ef3__education_service_centers', ['k_education_service_center']) }}

--- a/models/staging/edfi_3/stage/stg_ef3__education_service_centers__identification_codes.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__education_service_centers__identification_codes.sql
@@ -5,7 +5,7 @@ flattened as (
     select 
         tenant_code,
         api_year,
-        k_service_center,
+        k_education_service_center,
         {{ extract_descriptor('value:educationOrganizationIdentificationSystemDescriptor::string') }} as id_system,
         value:identificationCode::string as id_code
     from stg_service_centers,


### PR DESCRIPTION
Added `webSite` and `stateEducationAgencyReference` fields to the base and stage models for education service centers. I missed these because they aren't present in the Boston data (thanks for catching this, Rob!)

Also renamed `k_service_center` to `k_education_service_center` for consistent naming with `dim_education_service_center.` The PR for `dim_education_service_center` in `edu_wh` has been updated to match.