### PR TITLE
Feature/extract extension many

### DIFF
--- a/macros/extract_extension.sql
+++ b/macros/extract_extension.sql
@@ -26,6 +26,7 @@
 
       {%- if ext_extract_descriptor %}
         {{extract_descriptor(full_ext_native_name)}}::{{ext_dtype}} as {{ext}}
+      {%- else -%}
         {{full_ext_native_name}}::{{ext_dtype}} as {{ext}}
       {%- endif %}    
 

--- a/macros/extract_extension.sql
+++ b/macros/extract_extension.sql
@@ -6,25 +6,39 @@
   -- for each extension, just return the col name
 #}
 {% macro extract_extension(model_name, flatten) %}
-{%- set extensions =  var('extensions')[model_name]  -%}
+
+{% if model_name is string %}
+    {% set model_name = [model_name] %}
+{% endif %}
+
+{% set extensions = [] -%}
+{%- for relation in model_name -%}
+    {%- for extension in var('extensions')[relation] -%}
+        {%- do extensions.append(extension) -%}
+    {%- endfor -%}
+{%- endfor %}
 
 {%- if extensions is defined and extensions|length > 0 -%},{% endif -%}
 
-{%- for ext in extensions %}
-  {%- set ext_native_name =  extensions[ext].name  -%}
-  {%- set full_ext_native_name =  'v_ext:' + ext_native_name  -%}
-  {%- set ext_dtype =  extensions[ext].dtype  -%}
-  {%- set ext_extract_descriptor =  extensions[ext].extract_descriptor  -%}
-  {%- if flatten %}
-    {%- if ext_extract_descriptor %}
-      {{extract_descriptor(full_ext_native_name)}}::{{ext_dtype}} as {{ext}}
+{%- for ext in extensions|unique %}
+    {%- set ext_native_name =  extensions[ext].name  -%}
+    {%- set full_ext_native_name =  'v_ext:' + ext_native_name  -%}
+    {%- set ext_dtype =  extensions[ext].dtype  -%}
+    {%- set ext_extract_descriptor =  extensions[ext].extract_descriptor -%}
+
+    {%- if flatten %}
+        {%- if ext_extract_descriptor %}
+            {{extract_descriptor(full_ext_native_name)}}::{{ext_dtype}} as {{ext}}
+        {%- else %}
+            {{full_ext_native_name}}::{{ext_dtype}} as {{ext}}
+        {%- endif %}
+
     {%- else %}
-      {{full_ext_native_name}}::{{ext_dtype}} as {{ext}}
-    {%- endif %}    
-  {%- else %}
-    {{ext}}
-  {%- endif %}
-  {%- if not loop.last %},{% endif -%}
+        {{ext}}
+
+    {%- endif %}
+    {%- if not loop.last %},{% endif -%}
+
 {%- endfor -%}
 
 {% endmacro %}

--- a/macros/extract_extension.sql
+++ b/macros/extract_extension.sql
@@ -7,6 +7,7 @@
 #}
 {% macro extract_extension(model_name, flatten) %}
 
+{# If `model_name` is a singleton, convert to a list. #}
 {% if model_name is string %}
     {% set model_name = [model_name] %}
 {% endif %}

--- a/macros/extract_extension.sql
+++ b/macros/extract_extension.sql
@@ -7,39 +7,59 @@
 #}
 {% macro extract_extension(model_name, flatten) %}
 
-{# If `model_name` is a singleton, convert to a list. #}
-{% if model_name is string %}
-    {% set model_name = [model_name] %}
-{% endif %}
+{# If `model_name` is not a singleton, use extract list function. #}
+{% if model_name is not string %}
+    {{ edu_edfi_source.extract_extension_list(model_name) }}
+{% else %}
+  {# if `model_name` IS a singleton, use var of its single model name #}
+  {%- set extensions =  var('extensions')[model_name]  -%}
 
-{% set extensions = [] -%}
-{%- for relation in model_name -%}
-    {%- for extension in var('extensions')[relation] -%}
-        {%- do extensions.append(extension) -%}
-    {%- endfor -%}
-{%- endfor %}
-
-{%- if extensions is defined and extensions|length > 0 -%},{% endif -%}
-
-{%- for ext in extensions|unique %}
-    {%- set ext_native_name =  extensions[ext].name  -%}
-    {%- set full_ext_native_name =  'v_ext:' + ext_native_name  -%}
-    {%- set ext_dtype =  extensions[ext].dtype  -%}
-    {%- set ext_extract_descriptor =  extensions[ext].extract_descriptor -%}
-
+  {%- for ext in extensions %}
+  
+    {# If flatten (as is done in stg models), pull out metadata from dbt_project var and use to flatten json into columns #}
     {%- if flatten %}
-        {%- if ext_extract_descriptor %}
-            {{extract_descriptor(full_ext_native_name)}}::{{ext_dtype}} as {{ext}}
-        {%- else %}
-            {{full_ext_native_name}}::{{ext_dtype}} as {{ext}}
-        {%- endif %}
+    
+      {%- set ext_native_name =  extensions[ext].name  -%}
+      {%- set full_ext_native_name =  'v_ext:' + ext_native_name  -%}
+      {%- set ext_dtype =  extensions[ext].dtype  -%}
+      {%- set ext_extract_descriptor =  extensions[ext].extract_descriptor  -%}
+
+      {%- if ext_extract_descriptor %}
+        {{extract_descriptor(full_ext_native_name)}}::{{ext_dtype}} as {{ext}}
+        {{full_ext_native_name}}::{{ext_dtype}} as {{ext}}
+      {%- endif %}    
 
     {%- else %}
-        {{ext}}
-
+      {{ext}}
     {%- endif %}
+
     {%- if not loop.last %},{% endif -%}
 
-{%- endfor -%}
+  {%- endfor -%}
+
+{% endif %}
+
+{% endmacro %}
+
+{# 
+  If model_name is a list, use this macro to find the unique names from those models
+   and print them. Note, flattening from a list of models is NOT supported, because
+   duplicate names would cause issues in metadata retrieval
+#}
+{% macro extract_extension_list(model_name) %}
+
+  {% set extensions = [] -%}
+  {%- for relation in model_name -%}
+      {%- for extension in var('extensions')[relation] -%}
+          {%- do extensions.append(extension) -%}
+      {%- endfor -%}
+  {%- endfor %}
+
+  {%- if extensions is defined and extensions|length > 0 -%},{% endif -%}
+
+  {%- for ext in extensions|unique %}
+    {{ext}}
+    {%- if not loop.last %},{% endif -%}
+  {%- endfor -%}
 
 {% endmacro %}

--- a/macros/extract_extension.sql
+++ b/macros/extract_extension.sql
@@ -14,6 +14,8 @@
   {# if `model_name` IS a singleton, use var of its single model name #}
   {%- set extensions =  var('extensions')[model_name]  -%}
 
+  {%- if extensions is defined and extensions|length > 0 -%},{% endif -%}
+
   {%- for ext in extensions %}
   
     {# If flatten (as is done in stg models), pull out metadata from dbt_project var and use to flatten json into columns #}


### PR DESCRIPTION
To support https://github.com/edanalytics/edu_wh/pull/40 , this expands `extract_extension()` to allow for a list of many values in `model_name`. For example, if you have a warehouse model that combines multiple staging models, and it needs to pull out the extension columns from all of them, you can feed `extract_extension` a list of model names, and it will find the **unique** column names across models, and print those as SQL

This will break if:
- two staging models have a shared extension column name, but those are substantively different and not meant to be stacked. This code expects that those data have been stacked (i.e. from a `union_relations`)
- you try to run the macro on a list of models, with `flatten=True`. The code will not flatten anything. Should we throw an error if this happens? How to throw exception in Jinja?