### PR TITLE
Bugfix/deletes case

### DIFF
--- a/macros/source_edfi3.sql
+++ b/macros/source_edfi3.sql
@@ -4,7 +4,7 @@
     {% if join_deletes %}
         select
             api_data.*,
-            get_ignore_case(to_object(deletes_data.v), 'id')::string is not null as is_deleted
+            get_ignore_case(deletes_data.v, 'id')::string is not null as is_deleted
 
         from {{ source('raw_edfi_3', resource) }} as api_data
 
@@ -13,7 +13,7 @@
                 deletes_data.name = '{{ resource | lower }}'
                 and api_data.tenant_code = deletes_data.tenant_code
                 and api_data.api_year = deletes_data.api_year
-                and api_data.v:id::string = replace(get_ignore_case(to_object(deletes_data.v), 'id')::string, '-')
+                and api_data.v:id::string = replace(get_ignore_case(deletes_data.v, 'id')::string, '-')
             )
 
     {% else %}

--- a/macros/source_edfi3.sql
+++ b/macros/source_edfi3.sql
@@ -4,7 +4,7 @@
     {% if join_deletes %}
         select
             api_data.*,
-            (deletes_data.v:Id::string is not null or deletes_data.v:id::string is not null) as is_deleted
+            get_ignore_case(to_object(deletes_data.v), 'id')::string is not null as is_deleted
 
         from {{ source('raw_edfi_3', resource) }} as api_data
 
@@ -13,8 +13,7 @@
                 deletes_data.name = '{{ resource | lower }}'
                 and api_data.tenant_code = deletes_data.tenant_code
                 and api_data.api_year = deletes_data.api_year
-                and (api_data.v:id::string = replace(deletes_data.v:Id::string, '-')
-                    or api_data.v:id::string = replace(deletes_data.v:id::string, '-'))
+                and api_data.v:id::string = replace(get_ignore_case(to_object(deletes_data.v), 'id')::string, '-')
             )
 
     {% else %}

--- a/macros/source_edfi3.sql
+++ b/macros/source_edfi3.sql
@@ -4,7 +4,7 @@
     {% if join_deletes %}
         select
             api_data.*,
-            deletes_data.v:Id::string is not null as is_deleted
+            (deletes_data.v:Id::string is not null or deletes_data.v:id::string is not null) as is_deleted
 
         from {{ source('raw_edfi_3', resource) }} as api_data
 
@@ -13,7 +13,8 @@
                 deletes_data.name = '{{ resource | lower }}'
                 and api_data.tenant_code = deletes_data.tenant_code
                 and api_data.api_year = deletes_data.api_year
-                and api_data.v:id::string = replace(deletes_data.v:Id::string, '-')
+                and (api_data.v:id::string = replace(deletes_data.v:Id::string, '-')
+                    or api_data.v:id::string = replace(deletes_data.v:id::string, '-'))
             )
 
     {% else %}


### PR DESCRIPTION
Ignore case when getting the id from the variant for deletes. There appears to be inconsistency in whether the id field comes from the API as lowercase `id` or first letter capitalized `Id`.

Tested and confirmed in Jeffco but could use testing in other environments as well.