### PR TITLE
Feature/replace numeric descriptors

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -32,6 +32,7 @@ models:
           +materialized: ephemeral
           int_ef3__deduped_descriptors:
            +materialized: table
+           +tags: ['bypass_rls']
         stage: 
           +materialized: table
           

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -30,6 +30,8 @@ models:
           +materialized: view
         intermediate:
           +materialized: ephemeral
+          int_ef3__deduped_descriptors:
+           +materialized: table
         stage: 
           +materialized: table
           

--- a/macros/extract_descriptor.sql
+++ b/macros/extract_descriptor.sql
@@ -2,7 +2,7 @@
 {% macro extract_descriptor(col) -%}
     
     {%- set stripped_col = col.split(":")[-3] -%}
-    {%- set config = var('descriptors')[stripped_col] or None -%}
+    {%- set config = var('descriptors', {}).get(stripped_col) or None -%}
     {%- set replace_with = config['replace_with'] or None -%}
 
     {# if not configured to replace (default), split part from raw value #}

--- a/macros/extract_descriptor.sql
+++ b/macros/extract_descriptor.sql
@@ -6,12 +6,12 @@
     {%- set replace_with_short_descr = config['replace_with_short_descr'] or False -%}
 
     -- if not configured to replace (default), split part from raw value
-    {%- if not replace_with_short_descr -%}
+    {%- if not replace_with_short_descr %}
 
       split_part({{ col }}, '#', -1)
 
-    -- if configured to replace, query int_ef3__deduped_descriptors to find each value's short description
     {%- else %}
+    -- if configured to replace, query int_ef3__deduped_descriptors to find each value's short description
       
       {% set query_descriptors -%}
         select namespace, code_value, description, short_description

--- a/macros/extract_descriptor.sql
+++ b/macros/extract_descriptor.sql
@@ -1,17 +1,17 @@
--- grab descriptor codes from namespaced descriptor values
+{# grab descriptor codes from namespaced descriptor values #}
 {% macro extract_descriptor(col) -%}
     
     {%- set stripped_col = col.split(":")[-3] -%}
     {%- set config = var('descriptors')[stripped_col] or None -%}
     {%- set replace_with = config['replace_with'] or None -%}
 
-    -- if not configured to replace (default), split part from raw value
+    {# if not configured to replace (default), split part from raw value #}
     {%- if not replace_with %}
 
       split_part({{ col }}, '#', -1)
 
     {%- else %}
-    -- if configured to replace, query int_ef3__deduped_descriptors to find each value's short description
+    {#- if configured to replace, query int_ef3__deduped_descriptors to find each value's short description -#}
       
       {% set query_descriptors -%}
         select namespace, code_value, {{ replace_with }}
@@ -27,7 +27,7 @@
         {%- set descriptions = descriptor_xwalk.columns[2].values() -%}
       {%- endif -%}
       
-      -- create a case/when statement that replaces each raw code_value with short_description
+      {# create a case/when statement that replaces each raw code_value with short_description #}
       case
       {% for i in range(code_values|length) -%}
 
@@ -35,7 +35,7 @@
           then '{{descriptions[i]}}'
 
       {% endfor %}
-        -- default to raw value if not found in descriptors table
+        {# default to raw value if not found in descriptors table #}
         else split_part({{ col }}, '#', -1)
         end       
     {%- endif -%}

--- a/macros/extract_descriptor.sql
+++ b/macros/extract_descriptor.sql
@@ -36,7 +36,7 @@
           then '{{short_descriptions[i]}}'
 
       {%- endfor %}
-        -- default to raw value if now found in descriptors table
+        -- default to raw value if not found in descriptors table
         else split_part({{ col }}, '#', -1)
         end       
     {%- endif -%}

--- a/macros/extract_descriptor.sql
+++ b/macros/extract_descriptor.sql
@@ -1,27 +1,29 @@
 -- grab descriptor codes from namespaced descriptor values
--- TODO decide how data should be returned, some options:
---   a) one value, either code value, long, or short description, based on config
---   b) if configured, create all three columns (sometimes only two?)
---   c) one value either code value, or nested json object with all three, based on config 
 {% macro extract_descriptor(col) -%}
     
     {%- set stripped_col = col.split(":")[1] -%}
     {%- set config = var('descriptors')[stripped_col] or None -%}
-    {%- set include_descriptions = config['include_descriptions'] or False -%}
+    {%- set replace_with_short_descr = config['replace_with_short_descr'] or False -%}
     {%- set alias = config['alias'] -%}
 
-    {%- if not include_descriptions -%}
+    -- if not configured to replace (default), split part from raw value
+    {%- if not replace_with_short_descr -%}
+
       split_part({{ col }}, '#', -1)
-    {%- elif include_descriptions and not alias -%}
-      {{ exceptions.raise_compiler_error("Error in extract_descriptor(): if include_descriptions is set, must define an alias") }}
+
+    {%- elif replace_with_short_descr and not alias -%}
+
+      {{ exceptions.raise_compiler_error("Error in extract_descriptor(): if replace_with_short_descr is set, must define an alias") }}
+
+    -- if configured to replace, query int_ef3__deduped_descriptors to find each value's short description
     {%- else %}
-      -- TODO split this into a separate macro below, once we decide how data should be returned
       
       {% set query_descriptors -%}
         select namespace, code_value, description, short_description
         from {{ ref('int_ef3__deduped_descriptors') }}
         where lower(split_part(namespace, '/', -1)) = lower('{{stripped_col}}')
       {%- endset -%}
+
       {%- set descriptor_xwalk = run_query(query_descriptors) %}
 
       {%- if execute -%}
@@ -31,10 +33,13 @@
         {%- set short_descriptions = descriptor_xwalk.columns[3].values() -%}
       {%- endif -%}
       
+      -- create a case/when statement that replaces each raw code_value with short_description
       case
-      {%- for i in range(code_values|length) %}
+      {%- for i in range(code_values|length) -%}
+
         when split_part({{ col }}, '#', 1) = '{{namespaces[i]}}' and split_part({{ col }}, '#', -1) = '{{code_values[i]}}'
           then '{{short_descriptions[i]}}'
+
       {%- endfor %}
         end       
     {%- endif -%}

--- a/macros/extract_descriptor.sql
+++ b/macros/extract_descriptor.sql
@@ -4,16 +4,11 @@
     {%- set stripped_col = col.split(":")[1] -%}
     {%- set config = var('descriptors')[stripped_col] or None -%}
     {%- set replace_with_short_descr = config['replace_with_short_descr'] or False -%}
-    {%- set alias = config['alias'] -%}
 
     -- if not configured to replace (default), split part from raw value
     {%- if not replace_with_short_descr -%}
 
       split_part({{ col }}, '#', -1)
-
-    {%- elif replace_with_short_descr and not alias -%}
-
-      {{ exceptions.raise_compiler_error("Error in extract_descriptor(): if replace_with_short_descr is set, must define an alias") }}
 
     -- if configured to replace, query int_ef3__deduped_descriptors to find each value's short description
     {%- else %}
@@ -35,12 +30,14 @@
       
       -- create a case/when statement that replaces each raw code_value with short_description
       case
-      {%- for i in range(code_values|length) -%}
+      {% for i in range(code_values|length) -%}
 
         when split_part({{ col }}, '#', 1) = '{{namespaces[i]}}' and split_part({{ col }}, '#', -1) = '{{code_values[i]}}'
           then '{{short_descriptions[i]}}'
 
       {%- endfor %}
+        -- default to raw value if now found in descriptors table
+        else split_part({{ col }}, '#', -1)
         end       
     {%- endif -%}
 {%- endmacro %}

--- a/macros/extract_descriptor.sql
+++ b/macros/extract_descriptor.sql
@@ -1,5 +1,4 @@
 -- grab descriptor codes from namespaced descriptor values
--- TODO is there a better way to handle trailing commas?
 -- TODO decide how data should be returned, some options:
 --   a) one value, either code value, long, or short description, based on config
 --   b) if configured, create all three columns (sometimes only two?)
@@ -19,29 +18,24 @@
       -- TODO split this into a separate macro below, once we decide how data should be returned
       
       {% set query_descriptors -%}
-        select tenant_code, api_year, namespace, code_value, description, short_description
-        from {{ ref('stg_ef3__descriptors') }}
+        select namespace, code_value, description, short_description
+        from {{ ref('bld_ef3__deduped_descriptors') }}
         where lower(split_part(namespace, '/', -1)) = lower('{{stripped_col}}')
       {%- endset -%}
       {%- set descriptor_xwalk = run_query(query_descriptors) %}
 
       {%- if execute -%}
-        {%- set tenant_codes = descriptor_xwalk.columns[0].values() -%}
-        {%- set api_years = descriptor_xwalk.columns[1].values() -%}
-        {%- set code_values = descriptor_xwalk.columns[3].values() -%}
-        {%- set descriptions = descriptor_xwalk.columns[4].values() -%}
-        {%- set short_descriptions = descriptor_xwalk.columns[5].values() -%}
+        {%- set namespaces = descriptor_xwalk.columns[0].values() -%}
+        {%- set code_values = descriptor_xwalk.columns[1].values() -%}
+        {%- set descriptions = descriptor_xwalk.columns[2].values() -%}
+        {%- set short_descriptions = descriptor_xwalk.columns[3].values() -%}
       {%- endif -%}
       
       case
       {%- for i in range(code_values|length) %}
-        when tenant_code = '{{tenant_codes[i]}}' and api_year = '{{api_years[i]}}' and split_part({{ col }}, '#', -1) = '{{code_values[i]}}'
+        when split_part({{ col }}, '#', 1) = '{{namespaces[i]}}' and split_part({{ col }}, '#', -1) = '{{code_values[i]}}'
           then '{{short_descriptions[i]}}'
       {%- endfor %}
-        end as {{alias}}_short_description,
-          
-      -- TODO MAYBE add `as {{alias}}` here, but leaving out now so that prior code is still compatible (prior code have aliases written in model directly)
-      split_part({{ col }}, '#', -1)
-      
+        end       
     {%- endif -%}
 {%- endmacro %}

--- a/macros/extract_descriptor.sql
+++ b/macros/extract_descriptor.sql
@@ -1,4 +1,47 @@
 -- grab descriptor codes from namespaced descriptor values
+-- TODO is there a better way to handle trailing commas?
+-- TODO decide how data should be returned, some options:
+--   a) one value, either code value, long, or short description, based on config
+--   b) if configured, create all three columns (sometimes only two?)
+--   c) one value either code value, or nested json object with all three, based on config 
 {% macro extract_descriptor(col) -%}
-    split_part({{ col }}, '#', -1)
+    
+    {%- set stripped_col = col.split(":")[1] -%}
+    {%- set config = var('descriptors')[stripped_col] or None -%}
+    {%- set include_descriptions = config['include_descriptions'] or False -%}
+    {%- set alias = config['alias'] -%}
+
+    {%- if not include_descriptions -%}
+      split_part({{ col }}, '#', -1)
+    {%- elif include_descriptions and not alias -%}
+      {{ exceptions.raise_compiler_error("Error in extract_descriptor(): if include_descriptions is set, must define an alias") }}
+    {%- else %}
+      -- TODO split this into a separate macro below, once we decide how data should be returned
+      
+      {% set query_descriptors -%}
+        select tenant_code, api_year, namespace, code_value, description, short_description
+        from {{ ref('stg_ef3__descriptors') }}
+        where lower(split_part(namespace, '/', -1)) = lower('{{stripped_col}}')
+      {%- endset -%}
+      {%- set descriptor_xwalk = run_query(query_descriptors) %}
+
+      {%- if execute -%}
+        {%- set tenant_codes = descriptor_xwalk.columns[0].values() -%}
+        {%- set api_years = descriptor_xwalk.columns[1].values() -%}
+        {%- set code_values = descriptor_xwalk.columns[3].values() -%}
+        {%- set descriptions = descriptor_xwalk.columns[4].values() -%}
+        {%- set short_descriptions = descriptor_xwalk.columns[5].values() -%}
+      {%- endif -%}
+      
+      case
+      {%- for i in range(code_values|length) %}
+        when tenant_code = '{{tenant_codes[i]}}' and api_year = '{{api_years[i]}}' and split_part({{ col }}, '#', -1) = '{{code_values[i]}}'
+          then '{{short_descriptions[i]}}'
+      {%- endfor %}
+        end as {{alias}}_short_description,
+          
+      -- TODO MAYBE add `as {{alias}}` here, but leaving out now so that prior code is still compatible (prior code have aliases written in model directly)
+      split_part({{ col }}, '#', -1)
+      
+    {%- endif -%}
 {%- endmacro %}

--- a/macros/extract_descriptor.sql
+++ b/macros/extract_descriptor.sql
@@ -1,12 +1,12 @@
 -- grab descriptor codes from namespaced descriptor values
 {% macro extract_descriptor(col) -%}
     
-    {%- set stripped_col = col.split(":")[1] -%}
+    {%- set stripped_col = col.split(":")[-3] -%}
     {%- set config = var('descriptors')[stripped_col] or None -%}
-    {%- set replace_with_short_descr = config['replace_with_short_descr'] or False -%}
+    {%- set replace_with = config['replace_with'] or None -%}
 
     -- if not configured to replace (default), split part from raw value
-    {%- if not replace_with_short_descr %}
+    {%- if not replace_with %}
 
       split_part({{ col }}, '#', -1)
 
@@ -14,7 +14,7 @@
     -- if configured to replace, query int_ef3__deduped_descriptors to find each value's short description
       
       {% set query_descriptors -%}
-        select namespace, code_value, description, short_description
+        select namespace, code_value, {{ replace_with }}
         from {{ ref('int_ef3__deduped_descriptors') }}
         where lower(split_part(namespace, '/', -1)) = lower('{{stripped_col}}')
       {%- endset -%}
@@ -25,7 +25,6 @@
         {%- set namespaces = descriptor_xwalk.columns[0].values() -%}
         {%- set code_values = descriptor_xwalk.columns[1].values() -%}
         {%- set descriptions = descriptor_xwalk.columns[2].values() -%}
-        {%- set short_descriptions = descriptor_xwalk.columns[3].values() -%}
       {%- endif -%}
       
       -- create a case/when statement that replaces each raw code_value with short_description
@@ -33,9 +32,9 @@
       {% for i in range(code_values|length) -%}
 
         when split_part({{ col }}, '#', 1) = '{{namespaces[i]}}' and split_part({{ col }}, '#', -1) = '{{code_values[i]}}'
-          then '{{short_descriptions[i]}}'
+          then '{{descriptions[i]}}'
 
-      {%- endfor %}
+      {% endfor %}
         -- default to raw value if not found in descriptors table
         else split_part({{ col }}, '#', -1)
         end       

--- a/macros/extract_descriptor.sql
+++ b/macros/extract_descriptor.sql
@@ -19,7 +19,7 @@
       
       {% set query_descriptors -%}
         select namespace, code_value, description, short_description
-        from {{ ref('bld_ef3__deduped_descriptors') }}
+        from {{ ref('int_ef3__deduped_descriptors') }}
         where lower(split_part(namespace, '/', -1)) = lower('{{stripped_col}}')
       {%- endset -%}
       {%- set descriptor_xwalk = run_query(query_descriptors) %}

--- a/macros/extract_extension.sql
+++ b/macros/extract_extension.sql
@@ -27,7 +27,7 @@
       {%- set ext_extract_descriptor =  extensions[ext].extract_descriptor  -%}
 
       {%- if ext_extract_descriptor %}
-        {{extract_descriptor(full_ext_native_name)}}::{{ext_dtype}} as {{ext}}
+        {{extract_descriptor(full_ext_native_name + '::string')}}::{{ext_dtype}} as {{ext}}
       {%- else -%}
         {{full_ext_native_name}}::{{ext_dtype}} as {{ext}}
       {%- endif %}    

--- a/models/staging/edfi_3/intermediate/int_ef3__deduped_descriptors.sql
+++ b/models/staging/edfi_3/intermediate/int_ef3__deduped_descriptors.sql
@@ -1,0 +1,29 @@
+-- this model deduplicates stg_ef3__descriptors across tenants & years, to simplify the code needed in edu_edfi_source.extract_descriptor
+    -- to replace descriptor code_values with short or long descriptions
+-- in the future, we could allow for more sophisticated order by logic, to not just select rows based on alphabetical tenant order
+with stg_descriptors as (
+    select * from {{ ref('stg_ef3__descriptors') }}
+),
+
+-- note, order by tenant and api to ensure consistency over time (although it will change as new tenants are added)
+-- todo: better way to configure the order by?
+deduped as (
+    {{
+        dbt_utils.deduplicate(
+            relation='stg_descriptors',
+            partition_by='namespace, code_value',
+            order_by='tenant_code, api_year desc'
+        )
+    }}
+),
+
+subset as (
+  select
+    namespace,
+    code_value,
+    description,
+    short_description
+  from deduped
+)
+
+select * from subset

--- a/models/staging/edfi_3/intermediate/int_ef3__deduped_descriptors.sql
+++ b/models/staging/edfi_3/intermediate/int_ef3__deduped_descriptors.sql
@@ -1,5 +1,5 @@
 -- this model deduplicates stg_ef3__descriptors across tenants & years, to simplify the code needed in edu_edfi_source.extract_descriptor
-    -- to replace descriptor code_values with short or long descriptions
+    -- to replace descriptor code_values with short descriptions
 -- in the future, we could allow for more sophisticated order by logic, to not just select rows based on alphabetical tenant order
 with stg_descriptors as (
     select * from {{ ref('stg_ef3__descriptors') }}


### PR DESCRIPTION
- Adds int model `int_ef3__deduped_descriptors.sql` to dedupe values from stg_descriptors across tenant & years. This is useful for texas & SC, where descriptors are common across all the districts, so by deduping, the new addition to the `extract_descriptor` macro can construct a simpler, more efficient `case when` statement.
- Adds logic to `extract_descriptor` to allow descriptor code values (commonly numeric codes) to be replaced with short descriptions, if configured. e.g. numeric race codes replaced with human-readable and dashboard-friendly written values

Note, I wrote this as a `case when` statement in the existing macro, to avoid duplicated code, to avoid any breaking changes, and to avoid the need for complicated conditional join logic. Also, if column names or descriptor values change in the future, no errors are introduced, and minimal maintenance is needed (sometimes changes to config will be needed, but otherwise changes will be dynamic with the descriptors we pull)

### Example configuration: 
```  
  descriptors:
    raceDescriptor:
      replace_with: short_description
    assessmentPeriodDescriptor:
      replace_with: description
    adaEligibilityDescriptor:
      replace_with: short_description
```