### PR TITLE
Hotfix/obj assess subjects

### DIFF
--- a/models/staging/edfi_3/stage/stg_ef3__objective_assessments.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__objective_assessments.sql
@@ -2,32 +2,42 @@ with base_obj_assessments as (
     select * from {{ ref('base_ef3__objective_assessments') }}
     where not is_deleted
 ),
-stg_assessments as (
-    select 
+stage_student_assessments as (
+    select * from {{ ref('stg_ef3__student_assessments') }}
+),
+distinct_obj_subject as (
+    select distinct
+        tenant_code,
+        api_year,
         assessment_identifier,
         namespace,
-        academic_subject
-    from {{ ref('stg_ef3__assessments') }}
+        academic_subject,
+        value:objectiveAssessmentReference:identificationCode::string as objective_assessment_identification_code
+    from stage_student_assessments,
+        lateral flatten(input => v_student_objective_assessments)
 ),
 keyed as (
     select
         {{ dbt_utils.surrogate_key(
-            ['tenant_code',
-            'api_year',
-            'lower(stg_assessments.academic_subject)',
+            ['base_obj_assessments.tenant_code',
+            'base_obj_assessments.api_year',
+            'lower(distinct_obj_subject.academic_subject)',
             'lower(base_obj_assessments.assessment_identifier)',
             'lower(base_obj_assessments.namespace)',
-            'lower(objective_assessment_identification_code)']
+            'lower(base_obj_assessments.objective_assessment_identification_code)']
         ) }} as k_objective_assessment,
-        {{ gen_skey('k_assessment', extras = ['stg_assessments.academic_subject']) }},
+        {{ gen_skey('k_assessment', extras = ['distinct_obj_subject.academic_subject']) }},
         base_obj_assessments.*,
-        stg_assessments.academic_subject
+        distinct_obj_subject.academic_subject
         {{ extract_extension(model_name=this.name, flatten=True) }}
     from base_obj_assessments
     -- point of this is to cross join objective assessments against the academic subjects to add to gen_skey
-    join stg_assessments 
-        on base_obj_assessments.assessment_identifier = stg_assessments.assessment_identifier
-        and base_obj_assessments.namespace = stg_assessments.namespace
+    join distinct_obj_subject 
+        on base_obj_assessments.tenant_code = distinct_obj_subject.tenant_code
+        and base_obj_assessments.api_year = distinct_obj_subject.api_year
+        and base_obj_assessments.assessment_identifier = distinct_obj_subject.assessment_identifier
+        and base_obj_assessments.namespace = distinct_obj_subject.namespace
+        and base_obj_assessments.objective_assessment_identification_code = distinct_obj_subject.objective_assessment_identification_code
 ),
 deduped as (
     {{


### PR DESCRIPTION
Goal here is to properly associate objective assessments to subjects. Previously, we were cross-joining all possible subjects from the list in the assessment resource to each objective assessment, but that meant that certain objective assessments such as 'Number and Quantity' were being associated to both ELA & Math, which caused issues downstream (and is also just wrong). 

There is no way to correctly link to a single subject unless we get that information from student assessment records, so the fix in this case is to determine the possible subjects from the `stg_ef3__student_assessments` for each tenant/yr/assessment/obj assessment ID. I decided to go with an inner merge back to objective assessments, though that means that only objective assessments with student assessment records will persist to the WH. I can imagine there is a use-case to keep all objective assessments regardless of student assessment records, but this will cause the least issues for existing products (Rally).