### PR TITLE
add escape to single quotes in descriptors

### DIFF
--- a/macros/extract_descriptor.sql
+++ b/macros/extract_descriptor.sql
@@ -17,6 +17,7 @@
         select namespace, code_value, {{ replace_with }}
         from {{ ref('int_ef3__deduped_descriptors') }}
         where lower(split_part(namespace, '/', -1)) = lower('{{stripped_col}}')
+        order by 1,2
       {%- endset -%}
 
       {%- set descriptor_xwalk = run_query(query_descriptors) %}
@@ -31,8 +32,9 @@
       case
       {% for i in range(code_values|length) -%}
 
-        when split_part({{ col }}, '#', 1) = '{{namespaces[i]}}' and split_part({{ col }}, '#', -1) = '{{code_values[i]}}'
-          then '{{descriptions[i]}}'
+        when split_part({{ col }}, '#', 1) = '{{namespaces[i]|replace("'", "\\'")}}'
+            and split_part({{ col }}, '#', -1) = '{{code_values[i]|replace("'", "\\'")}}'
+          then '{{descriptions[i]|replace("'", "\\'")}}'
 
       {% endfor %}
         {# default to raw value if not found in descriptors table #}


### PR DESCRIPTION
I found that some cases of descriptors fail when we config to replace, bc their code_value or short_description contain single quotes

e.g. code_value 'Master's' for levelOfEducationDescriptor
  or short_description 'Côte d'Ivoire' for countryDescriptor
  or short_descrption 'College, Pursue Associate's or Bachelor's Degree' (Texas-specific value) for exitWithdrawTypeDescriptor 

this fix adds an escape character so the sql can successfully compile. Tested on Texas for `exitWithdrawTypeDescriptor` case