### PR TITLE
Enable/disable disability model with program flag

### DIFF
--- a/models/staging/edfi_3/stage/_edfi_3__stage.yml
+++ b/models/staging/edfi_3/stage/_edfi_3__stage.yml
@@ -536,6 +536,11 @@ models:
       tags: ['language_instruction']
       enabled: "{{ var('src:program:language_instruction:enabled', True) }}"
 
+  - name: stg_ef3__stu_spec_ed__disabilities
+    config:
+      tags: ['special_ed']
+      enabled: "{{ var('src:program:special_ed:enabled', True) }}"
+
   - name: stg_ef3__stu_spec_ed__program_services
     config:
       tags: ['special_ed']


### PR DESCRIPTION
There was a small bug in the disabilities model update. The model needs to be disabled if the special ed programs model is disabled (same logic as program services), otherwise dbt will not run. This was causing an issue in Jeffco but I tested with this tweak to the source package and it works.