### PR TITLE
Hotfix/dropped behaviors bug

### DIFF
--- a/models/staging/edfi_3/stage/stg_ef3__student_discipline_incident_behavior_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_discipline_incident_behavior_associations.sql
@@ -60,7 +60,7 @@ deduped as (
     {{
         dbt_utils.deduplicate(
             relation='keyed',
-            partition_by='k_student, k_discipline_incident',
+            partition_by='k_student, k_discipline_incident', 'behavior_type'
             order_by='pull_timestamp desc'
         )
     }}

--- a/models/staging/edfi_3/stage/stg_ef3__student_discipline_incident_behavior_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_discipline_incident_behavior_associations.sql
@@ -60,7 +60,7 @@ deduped as (
     {{
         dbt_utils.deduplicate(
             relation='keyed',
-            partition_by='k_student, k_discipline_incident', 'behavior_type'
+            partition_by='k_student, k_discipline_incident, behavior_type',
             order_by='pull_timestamp desc'
         )
     }}


### PR DESCRIPTION
Need to add `behavior_type` in the dedupe of `stg_ef3__student_discipline_incident_behavior_associations` because behavior is part of the grain and this was forcing a single behavior for a student/incident.