### PR TITLE
fix dedupe in combined behavior stg model - should include tenant & year

### DIFF
--- a/models/staging/edfi_3/stage/stg_ef3__discipline_actions.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__discipline_actions.sql
@@ -8,6 +8,7 @@ keyed as (
         {{ gen_skey('k_student_xyear') }},
         {{ gen_skey('k_school', alt_ref='assignment_school_reference', alt_k_name='k_school__assignment') }},
         {{ gen_skey('k_school', alt_ref='responsibility_school_reference', alt_k_name='k_school__responsibility') }},
+        api_year as school_year,
         base_discipline_actions.*
         {{ extract_extension(model_name=this.name, flatten=True) }}
     from base_discipline_actions

--- a/models/staging/edfi_3/stage/stg_ef3__discipline_incidents.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__discipline_incidents.sql
@@ -11,6 +11,7 @@ keyed as (
              'school_id']
         ) }} as k_discipline_incident,
         {{ gen_skey('k_school') }},
+        api_year as school_year,
         base_discipline_incident.*
         {{ extract_extension(model_name=this.name, flatten=True) }}
     from base_discipline_incident

--- a/models/staging/edfi_3/stage/stg_ef3__student_discipline_incident_behavior_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_discipline_incident_behavior_associations.sql
@@ -52,6 +52,7 @@ keyed as (
         {{ gen_skey('k_student_xyear') }},
         {{ gen_skey('k_school', 'discipline_incident_reference') }},
         {{ gen_skey('k_discipline_incident') }},
+        api_year as school_year,
         stacked.*
         {{ extract_extension(model_name=this.name, flatten=True) }}
     from stacked

--- a/models/staging/edfi_3/stage/stg_ef3__student_discipline_incident_behavior_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_discipline_incident_behavior_associations.sql
@@ -10,7 +10,7 @@ dedupe_base_student_discipline_incident  as (
     {{
         dbt_utils.deduplicate(
             relation='base_student_discipline_incident',
-            partition_by='student_unique_id, school_id, incident_id',
+            partition_by='tenant_code, api_year, student_unique_id, school_id, incident_id',
             order_by='pull_timestamp desc'
         )
     }}


### PR DESCRIPTION
The dedupe here should include tenant & year, to match the unique key of k_discipline_incident.

Tested on Boston, where this is needed because of their multiyear ODS -- for years 2017-2022, all of their `student_discipline_incident_associations` records are duplicated for each api_year, because we run repeated pulls on the multiyear ODS with different values for api_year.

 Without including tenant & api_year in the dedupe, this dedupe just takes one record, assigned to whichever api_year is the last we pulled. We instead want all records to flow through stg, and handle the duplicates downstream (either with boston-specific queries, or a feature that removes incident dates that fall outside the school year)