### PR TITLE
Build/Learning standards Models

### DIFF
--- a/models/staging/edfi_3/base/_edfi_3__base.yml
+++ b/models/staging/edfi_3/base/_edfi_3__base.yml
@@ -59,6 +59,9 @@ models:
   - name: base_ef3__graduation_plans
     config:
       tags: ['core']
+  - name: base_ef3__learning_standards
+    config:
+      tags: ['core']
   - name: base_ef3__local_education_agencies
     config:
       tags: ['core']

--- a/models/staging/edfi_3/base/base_ef3__learning_standards.sql
+++ b/models/staging/edfi_3/base/base_ef3__learning_standards.sql
@@ -1,0 +1,34 @@
+with learning_standards as (
+    {{ source_edfi3('learning_standards') }}
+),
+renamed as (
+    select
+        tenant_code,
+        api_year,
+        pull_timestamp,
+        file_row_number,
+        filename,
+        is_deleted,
+        -- ids
+        v:id::string                              as record_guid,
+        v:learningStandardId::string              as learning_standard_id,
+        v:learningStandardIdentificationCode      as learning_standard_identification_code,
+        -- descriptions
+        v:learningStandardItemCode::string        as learning_standard_item_code,
+        v:learningStandardCategory                as learning_standard_category,
+        v:learningStandardScope                   as learning_standard_scope,
+        v:academicSubjects                        as academic_subjects,
+        v:contentStandard                         as content_standard,
+        v:courseTitle::string                     as course_title,
+        v:description::string                     as course_description,
+        v:gradeLevels                             as grade_level,
+        -- references
+        v:parentLearningStandardReference         as parent_learning_standard_reference,
+        v:successCriteria::string                 as success_criteria,
+        v:namespace::string                       as namespace,
+        v:uri::string                             as uri,
+        -- edfi extensions
+        v:_ext                                    as v_ext
+    from learning_standards
+)
+select * from renamed

--- a/models/staging/edfi_3/base/base_ef3__learning_standards.sql
+++ b/models/staging/edfi_3/base/base_ef3__learning_standards.sql
@@ -21,7 +21,7 @@ renamed as (
         v:contentStandard                         as v_content_standard,
         v:courseTitle::string                     as course_title,
         v:description::string                     as learning_standard_description,
-        v:gradeLevels                             as v_grade_level,
+        v:gradeLevels                             as v_grade_levels,
         -- references
         v:parentLearningStandardReference         as parent_learning_standard_reference,
         v:successCriteria::string                 as success_criteria,

--- a/models/staging/edfi_3/base/base_ef3__learning_standards.sql
+++ b/models/staging/edfi_3/base/base_ef3__learning_standards.sql
@@ -12,11 +12,11 @@ renamed as (
         -- ids
         v:id::string                              as record_guid,
         v:learningStandardId::string              as learning_standard_id,
-        v:learningStandardIdentificationCode      as v_learning_standard_identification_code,
+        v:identificationCodes                     as v_learning_standard_identification_codes,
         -- descriptions
         v:learningStandardItemCode::string        as learning_standard_item_code,
-        v:learningStandardCategory                as v_learning_standard_category,
-        v:learningStandardScope                   as v_learning_standard_scope,
+        v:learningStandardCategoryDescriptor      as v_learning_standard_category_descriptor,
+        v:learningStandardScopeDescriptor         as v_learning_standard_scope_descriptor,
         v:academicSubjects                        as v_academic_subjects,
         v:contentStandard                         as v_content_standard,
         v:courseTitle::string                     as course_title,

--- a/models/staging/edfi_3/base/base_ef3__learning_standards.sql
+++ b/models/staging/edfi_3/base/base_ef3__learning_standards.sql
@@ -12,16 +12,16 @@ renamed as (
         -- ids
         v:id::string                              as record_guid,
         v:learningStandardId::string              as learning_standard_id,
-        v:learningStandardIdentificationCode      as learning_standard_identification_code,
+        v:learningStandardIdentificationCode      as v_learning_standard_identification_code,
         -- descriptions
         v:learningStandardItemCode::string        as learning_standard_item_code,
-        v:learningStandardCategory                as learning_standard_category,
-        v:learningStandardScope                   as learning_standard_scope,
-        v:academicSubjects                        as academic_subjects,
-        v:contentStandard                         as content_standard,
+        v:learningStandardCategory                as v_learning_standard_category,
+        v:learningStandardScope                   as v_learning_standard_scope,
+        v:academicSubjects                        as v_academic_subjects,
+        v:contentStandard                         as v_content_standard,
         v:courseTitle::string                     as course_title,
-        v:description::string                     as course_description,
-        v:gradeLevels                             as grade_level,
+        v:description::string                     as learning_standard_description,
+        v:gradeLevels                             as v_grade_level,
         -- references
         v:parentLearningStandardReference         as parent_learning_standard_reference,
         v:successCriteria::string                 as success_criteria,

--- a/models/staging/edfi_3/stage/_edfi_3__stage.yml
+++ b/models/staging/edfi_3/stage/_edfi_3__stage.yml
@@ -300,6 +300,10 @@ models:
       tags: ['esc']
       enabled: "{{ var('src:ed_orgs:esc:enabled', True) }}"
 
+  - name: stg_ef3__grades__learning_standards
+    config:
+      tags: ['core']
+  
   - name: stg_ef3__grades
     config:
       tags: ['core']
@@ -326,6 +330,10 @@ models:
           *ref_k_school
 
   - name: stg_ef3__graduation_plans
+    config:
+      tags: ['core']
+
+  - name: stg_ef3__learning_standards
     config:
       tags: ['core']
 

--- a/models/staging/edfi_3/stage/stg_ef3__grades__learning_standards.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__grades__learning_standards.sql
@@ -4,13 +4,13 @@ with stg_grades as (
 ),
 flattened as (
     select
+        stg_grades.tenant_code,
+        stg_grades.api_year,
         stg_grades.k_student,
         stg_grades.k_school,
         stg_grades.k_grading_period,
         stg_grades.k_course_section,
         stg_grades.grade_type,
-        stg_grades.tenant_code,
-        stg_grades.api_year,
         v_lsg.value:learningStandardReference:learningStandardId::string as learning_standard_id,
         v_lsg.value:letterGradeEarned::string as learning_standard_letter_grade_earned,
         v_lsg.value:numericGradeEarned::string as learning_standard_numeric_grade_earned,

--- a/models/staging/edfi_3/stage/stg_ef3__grades__learning_standards.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__grades__learning_standards.sql
@@ -12,8 +12,8 @@ flattened as (
         stg_grades.tenant_code,
         stg_grades.api_year,
         v_lsg.value:learningStandardReference:learningStandardId::string as learning_standard_id,
-        v_lsg.value:letterGradeEarned::string as letter_grade_earned,
-        v_lsg.value:numericGradeEarned::string as numeric_grade_earned,
+        v_lsg.value:letterGradeEarned::string as learning_standard_letter_grade_earned,
+        v_lsg.value:numericGradeEarned::string as learning_standard_numeric_grade_earned,
         {{ edu_edfi_source.extract_descriptor('v_lsg.value:performanceBaseConversionDescriptor::string') }} as performance_base_conversion_descriptor
     from stg_grades,
         lateral flatten(input=>v_learning_standard_grades, outer=>true) as v_lsg

--- a/models/staging/edfi_3/stage/stg_ef3__grades__learning_standards.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__grades__learning_standards.sql
@@ -1,0 +1,15 @@
+with stg_grades as (
+    select * from {{ ref('stg_ef3__grades') }}
+    where not is_deleted
+),
+flattened as (
+    select
+        stg_grades.* exclude(letter_grade_earned, numeric_grade_earned),
+        v_lsg.value:learningStandardReference:learningStandardId::string as learning_standard_id,
+        v_lsg.value:letterGradeEarned::string as letter_grade_earned,
+        v_lsg.value:numericGradeEarned::string as numeric_grade_earned,
+        {{ edu_edfi_source.extract_descriptor('v_lsg.value:performanceBaseConversionDescriptor::string') }} as performance_base_conversion_descriptor
+    from stg_grades,
+        lateral flatten(input=>v_learning_standard_grades, outer=>true) as v_lsg
+)
+select * from flattened

--- a/models/staging/edfi_3/stage/stg_ef3__grades__learning_standards.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__grades__learning_standards.sql
@@ -4,10 +4,10 @@ with stg_grades as (
 ),
 flattened as (
     select
-        stg_grades.*,
+        stg_grades.* exclude(letter_grade_earned, numeric_grade_earned),
         v_lsg.value:learningStandardReference:learningStandardId::string as learning_standard_id,
-        v_lsg.value:letterGradeEarned::string as learning_standard_letter_grade_earned,
-        v_lsg.value:numericGradeEarned::string as learning_standard_numeric_grade_earned,
+        v_lsg.value:letterGradeEarned::string as letter_grade_earned,
+        v_lsg.value:numericGradeEarned::string as numeric_grade_earned,
         {{ edu_edfi_source.extract_descriptor('v_lsg.value:performanceBaseConversionDescriptor::string') }} as performance_base_conversion_descriptor
     from stg_grades,
         lateral flatten(input=>v_learning_standard_grades, outer=>true) as v_lsg

--- a/models/staging/edfi_3/stage/stg_ef3__grades__learning_standards.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__grades__learning_standards.sql
@@ -4,8 +4,13 @@ with stg_grades as (
 ),
 flattened as (
     select
+        stg_grades.k_student,
+        stg_grades.k_school,
+        stg_grades.k_grading_period,
+        stg_grades.k_course_section,
         stg_grades.grade_type,
         stg_grades.tenant_code,
+        stg_grades.api_year,
         v_lsg.value:learningStandardReference:learningStandardId::string as learning_standard_id,
         v_lsg.value:letterGradeEarned::string as letter_grade_earned,
         v_lsg.value:numericGradeEarned::string as numeric_grade_earned,

--- a/models/staging/edfi_3/stage/stg_ef3__grades__learning_standards.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__grades__learning_standards.sql
@@ -4,7 +4,9 @@ with stg_grades as (
 ),
 flattened as (
     select
-        stg_grades.* exclude(letter_grade_earned, numeric_grade_earned),
+        stg_grades.grade_type,
+        stg_grades.tenant_code,
+        stg_grades.performance_base_conversion_descriptor,
         v_lsg.value:learningStandardReference:learningStandardId::string as learning_standard_id,
         v_lsg.value:letterGradeEarned::string as letter_grade_earned,
         v_lsg.value:numericGradeEarned::string as numeric_grade_earned,

--- a/models/staging/edfi_3/stage/stg_ef3__grades__learning_standards.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__grades__learning_standards.sql
@@ -6,7 +6,6 @@ flattened as (
     select
         stg_grades.grade_type,
         stg_grades.tenant_code,
-        stg_grades.performance_base_conversion_descriptor,
         v_lsg.value:learningStandardReference:learningStandardId::string as learning_standard_id,
         v_lsg.value:letterGradeEarned::string as letter_grade_earned,
         v_lsg.value:numericGradeEarned::string as numeric_grade_earned,

--- a/models/staging/edfi_3/stage/stg_ef3__grades__learning_standards.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__grades__learning_standards.sql
@@ -4,10 +4,10 @@ with stg_grades as (
 ),
 flattened as (
     select
-        stg_grades.* exclude(letter_grade_earned, numeric_grade_earned),
+        stg_grades.*,
         v_lsg.value:learningStandardReference:learningStandardId::string as learning_standard_id,
-        v_lsg.value:letterGradeEarned::string as letter_grade_earned,
-        v_lsg.value:numericGradeEarned::string as numeric_grade_earned,
+        v_lsg.value:letterGradeEarned::string as learning_standard_letter_grade_earned,
+        v_lsg.value:numericGradeEarned::string as learning_standard_numeric_grade_earned,
         {{ edu_edfi_source.extract_descriptor('v_lsg.value:performanceBaseConversionDescriptor::string') }} as performance_base_conversion_descriptor
     from stg_grades,
         lateral flatten(input=>v_learning_standard_grades, outer=>true) as v_lsg

--- a/models/staging/edfi_3/stage/stg_ef3__learning_standards.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__learning_standards.sql
@@ -9,11 +9,9 @@ keyed as (
             'api_year',
             'learning_standard_id']
         ) }} as k_learning_standard,
-        base_learning_standards.*,
-        {{ extract_descriptor('ls_academic_subject.value:academicSubjectDescriptor::string') }} as academic_subject_descriptor
+        base_learning_standards.*
         {{ extract_extension(model_name=this.name, flatten=True) }}
     from base_learning_standards,
-        lateral flatten(input=>v_academic_subjects, outer=>true) as ls_academic_subject
 ),
 deduped as (
     {{

--- a/models/staging/edfi_3/stage/stg_ef3__learning_standards.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__learning_standards.sql
@@ -2,7 +2,6 @@ with base_learning_standards as (
     select * from {{ ref('base_ef3__learning_standards') }}
     where not is_deleted
 ),
-
 keyed as (
     select
         {{ dbt_utils.surrogate_key(
@@ -14,7 +13,7 @@ keyed as (
         {{ extract_descriptor('ls_academic_subject.value:academicSubjectDescriptor::string') }} as academic_subject_descriptor
         {{ extract_extension(model_name=this.name, flatten=True) }}
     from base_learning_standards,
-        lateral flatten(input=>academic_subjects, outer=>true) as ls_academic_subject
+        lateral flatten(input=>v_academic_subjects, outer=>true) as ls_academic_subject
 ),
 deduped as (
     {{

--- a/models/staging/edfi_3/stage/stg_ef3__learning_standards.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__learning_standards.sql
@@ -1,0 +1,28 @@
+with base_learning_standards as (
+    select * from {{ ref('base_ef3__learning_standards') }}
+    where not is_deleted
+),
+
+keyed as (
+    select
+        {{ dbt_utils.surrogate_key(
+            ['tenant_code',
+            'api_year',
+            'learning_standard_id']
+        ) }} as k_learning_standard,
+        base_learning_standards.*,
+        {{ extract_descriptor('ls_academic_subject.value:academicSubjectDescriptor::string') }} as academic_subject_descriptor
+        {{ extract_extension(model_name=this.name, flatten=True) }}
+    from base_learning_standards,
+        lateral flatten(input=>academic_subjects, outer=>true) as ls_academic_subject
+),
+deduped as (
+    {{
+        dbt_utils.deduplicate(
+            relation='keyed',
+            partition_by='k_learning_standard',
+            order_by='pull_timestamp desc'
+        )
+    }}
+)
+select * from deduped

--- a/models/staging/edfi_3/stage/stg_ef3__learning_standards.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__learning_standards.sql
@@ -11,7 +11,7 @@ keyed as (
         ) }} as k_learning_standard,
         base_learning_standards.*
         {{ extract_extension(model_name=this.name, flatten=True) }}
-    from base_learning_standards,
+    from base_learning_standards
 ),
 deduped as (
     {{


### PR DESCRIPTION
## Description & motivation
This PR creates models for learning standard data to be used downstream by student grade tables.

## Changes to existing models:
- `_edfi_3__base` and  `_edfi_3__stage`: Added configurations for new base and staging models.

## New models created:
- `base_ef3__learning_standards` : Pulls raw [learning standards data ](https://schema.ed-fi.org/datahandbook-v330a/index.html#/LearningStandard567) columns to be used in downstream models. 
- `stg_ef3__learning_standards` : Extends `base_ef3__learning_standards` by adding surrogate keys, and extracting academic subject descriptors.
- `stg_ef3__grades__learning_standards` : Extracts student's learning standard grades and performance conversions.

## Tests and QC done:
- Executed a successful dbt run.
- Queried both Boston and Jeffco data warehouses to ensure data was accurately populated in the tables.
- Validated the granularity of the tables by querying each learning standard ID in the learning standard tables and cross-referencing it with a student, course section, school, grading period, and learning standard in the student learning standard grades table.
- Counted rows throughout to ensure there was no fan out of data, and queried distinct values to ensure data was represented properly.

## Future ToDos & Questions:
- Want to confirm that the yml configurations are consistent with the rest of the models in the yml file. Are there any other tests or configs that should be added? Anything about the foreign keys?
- There is a question about the grade range a student can earn through a learning standard (what is the max? the min?). We have not yet been able to come to a solution for this since this data doesn't seem to be coming through from the learning standard source (there is an ongoing conversation between Jordan, Rob, and me about this).
- Academic subject values can sometimes appear cryptic (ex: `F1FC8A52-3B53-11E0-B042-495E9DFF4B22` ) however, in other instances, the naming convention is more conventional, such as "`Science`." We should consider if there's a way to transform them into more readable subject names or if they are helpful as is.
- Some `learning_standard_id` values have some helpful descriptions (ex: `Math-Effort_rbcX200MATH00000010001111000`) while some are less helpful (ex: `c86bc12e-e6e3-467b-b8a8-bacc46c95b37`) for now we don't do anything with this column but it is something to consider for the future.

## PR Merge Priority:
<!---
This checklist helps the reviewers understand the level of priority for merging this PR.
-->
- [x] Low
- [ ] Medium
- [ ] High