### PR TITLE
fix/add ed org reference to cohorts

### DIFF
--- a/models/staging/edfi_3/stage/stg_ef3__cohorts.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__cohorts.sql
@@ -10,6 +10,7 @@ keyed as (
             'lower(cohort_id)',
             'ed_org_id']
         ) }} as k_cohort, 
+        {{ edorg_ref() }},
         api_year as school_year,
         base_cohorts.*
         {{ extract_extension(model_name=this.name, flatten=True) }}


### PR DESCRIPTION
## Description & motivation
Adds `k_lea` and `k_school` to `stg_ef3__cohorts`, for use in downstream models.

Related to this [edu_wh PR.](https://github.com/edanalytics/edu_wh/pull/78)

## PR Merge Priority:
- [x] Low

## Changes to existing files:
- `stg_ef3__cohorts.sql` : Add the `edorg_ref` marco

## Tests and QC done:
- Ran the models successfully in GSN and South Carolina
