### PR TITLE
add cohort tags

### DIFF
--- a/models/staging/edfi_3/base/_edfi_3__base.yml
+++ b/models/staging/edfi_3/base/_edfi_3__base.yml
@@ -19,7 +19,7 @@ models:
       tags: ['core']
   - name: base_ef3__cohorts
     config:
-      tags: ['core']
+      tags: ['cohort']
   - name: base_ef3__course_offerings
     config:
       tags: ['core']
@@ -108,7 +108,7 @@ models:
       enabled: "{{ var('src:domain:assessment:enabled', True) }}"
   - name: base_ef3__student_cohort_associations
     config:
-      tags: ['core']
+      tags: ['cohort']
   - name: base_ef3__student_discipline_incident_associations
     config:
       tags: ['discipline']

--- a/models/staging/edfi_3/stage/_edfi_3__stage.yml
+++ b/models/staging/edfi_3/stage/_edfi_3__stage.yml
@@ -198,10 +198,6 @@ models:
   - name: stg_ef3__cohorts
     config:
       tags: ['cohort']
-    columns:
-      - name: k_cohort
-        tests:
-          *ref_k_cohort
 
   - name: stg_ef3__course_offerings
     config:

--- a/models/staging/edfi_3/stage/_edfi_3__stage.yml
+++ b/models/staging/edfi_3/stage/_edfi_3__stage.yml
@@ -195,6 +195,14 @@ models:
         tests:
           *ref_k_school
 
+  - name: stg_ef3__cohorts
+    config:
+      tags: ['cohort']
+    columns:
+      - name: k_cohort
+        tests:
+          *ref_k_cohort
+
   - name: stg_ef3__course_offerings
     config:
       tags: ['core']
@@ -600,7 +608,7 @@ models:
 
   - name: stg_ef3__student_cohort_associations
     config:
-      tags: [ 'core' ]
+      tags: [ 'cohort' ]
     columns:
       - name: k_student
         tests:


### PR DESCRIPTION
## Description & motivation
Adds a `cohort` tag to cohort-related base and stage models.

Related to this [edu_wh PR.](https://github.com/edanalytics/edu_wh/pull/78)

## PR Merge Priority:
- [x] Low

## Changes to existing files:
- `_edfi_3__base.yml` : Update tags 
- `_edfi_3__stage.yml` : Add config block for `stg_ef3__cohorts` and update tags

## Tests and QC done:
- Ran the models successfully in GSN 