### PR TITLE
Student academic records - fix ordering

### DIFF
--- a/models/staging/edfi_3/stage/_edfi_3__stage.yml
+++ b/models/staging/edfi_3/stage/_edfi_3__stage.yml
@@ -567,10 +567,6 @@ models:
   - name: stg_ef3__student_academic_records
     config:
       tags: ['core']
-    columns:
-      - name: k_student
-        tests:
-          *ref_k_student
 
   - name: stg_ef3__student_academic_records__gpas
     config:

--- a/models/staging/edfi_3/stage/_edfi_3__stage.yml
+++ b/models/staging/edfi_3/stage/_edfi_3__stage.yml
@@ -567,6 +567,10 @@ models:
   - name: stg_ef3__student_academic_records
     config:
       tags: ['core']
+    columns:
+      - name: k_student
+        tests:
+          *ref_k_student
 
   - name: stg_ef3__student_academic_records__gpas
     config:

--- a/models/staging/edfi_3/stage/stg_ef3__course_transcripts.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__course_transcripts.sql
@@ -15,7 +15,7 @@ deduped as (
         dbt_utils.deduplicate(
             relation='keyed',
             partition_by='k_course, k_student_academic_record, course_attempt_result',
-            order_by='pull_timestamp desc'
+            order_by='api_year desc, pull_timestamp desc'
         )
     }}
 )

--- a/models/staging/edfi_3/stage/stg_ef3__student_academic_records.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_academic_records.sql
@@ -24,7 +24,7 @@ deduped as (
         dbt_utils.deduplicate(
             relation='keyed',
             partition_by='k_student_academic_record',
-            order_by='pull_timestamp desc'
+            order_by='api_year desc, pull_timestamp desc'
         )
     }}
 )

--- a/models/staging/edfi_3/stage/stg_ef3__student_academic_records.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_academic_records.sql
@@ -13,9 +13,7 @@ keyed as (
                 'lower(academic_term)'
             ]
         ) }} as k_student_academic_record,
-        {{ gen_skey('k_student') }}, --todo: or k_student_xyear?
-        -- todo: can we use ed_org_ref to generate either a k_school or k_lea here
-        -- note: appears to be driven by the same logic as student_ed_org_assoc, so could use a single variable for both
+        {{ gen_skey('k_student_xyear') }},
         {{ edorg_ref(annualize=False) }},
         base_academic_records.*
         {{ extract_extension(model_name=this.name, flatten=True) }}
@@ -25,7 +23,7 @@ deduped as (
     {{
         dbt_utils.deduplicate(
             relation='keyed',
-            partition_by='k_student_academic_record, ed_org_id',
+            partition_by='k_student_academic_record',
             order_by='pull_timestamp desc'
         )
     }}

--- a/models/staging/edfi_3/stage/stg_ef3__student_academic_records.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_academic_records.sql
@@ -13,8 +13,8 @@ keyed as (
                 'lower(academic_term)'
             ]
         ) }} as k_student_academic_record,
-        {{ gen_skey('k_student_xyear') }},
         {{ gen_skey('k_student') }},
+        {{ gen_skey('k_student_xyear') }},
         {{ edorg_ref(annualize=False) }},
         base_academic_records.*
         {{ extract_extension(model_name=this.name, flatten=True) }}

--- a/models/staging/edfi_3/stage/stg_ef3__student_academic_records.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_academic_records.sql
@@ -14,6 +14,7 @@ keyed as (
             ]
         ) }} as k_student_academic_record,
         {{ gen_skey('k_student_xyear') }},
+        {{ gen_skey('k_student') }},
         {{ edorg_ref(annualize=False) }},
         base_academic_records.*
         {{ extract_extension(model_name=this.name, flatten=True) }}


### PR DESCRIPTION
## Description & motivation
The student academic record models currently include `k_student` only, which excludes any historical records from years prior to the earliest `dim_student` records. This PR adds `k_student_xyear` and corrects the dedupe ordering logic to keep records from the post recent api_year.

## Changes to existing files:
- `_edfi_3__stage.yml` : remove k_student ref test
- `stg_ef3__student_academic_records` : add `k_student_xyear`; correct ordering logic; remove redundant field in the partition

## Tests and QC done (together with [edu_wh](https://github.com/edanalytics/edu_wh/pull/95)):
- Confirmed that row counts were unchanged in Jeffco

## PR Merge Priority:
Low - note that [this edu_wh PR](https://github.com/edanalytics/edu_wh/pull/95) depends on it