### PR TITLE
bugfix/student assessment deletes

### DIFF
--- a/models/staging/edfi_3/stage/stg_ef3__student_assessments.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_assessments.sql
@@ -1,5 +1,6 @@
 with int_stu_assessments as (
     select * from {{ ref('int_ef3__student_assessments__identify_subject') }}
+    where not is_deleted
 ),
 keyed as (
     select


### PR DESCRIPTION
Adds a filter on deleted records to `stg_ef3__student_assessments`. Tested and confirmed that deleted records were excluded in Denver and GSN.