### PR TITLE
Bugfix/staff student lower keys

### DIFF
--- a/models/staging/edfi_3/stage/stg_ef3__staffs.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__staffs.sql
@@ -7,7 +7,7 @@ keyed as (
         {{ dbt_utils.surrogate_key(
             [
                 'tenant_code',
-                'staff_unique_id'
+                'lower(staff_unique_id)'
             ]
         ) }} as k_staff,
         base_staffs.*

--- a/models/staging/edfi_3/stage/stg_ef3__students.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__students.sql
@@ -9,7 +9,7 @@ keyed as (
             [
                 'tenant_code',
                 'api_year',
-                'student_unique_id'
+                'lower(student_unique_id)'
             ]
         ) }} as k_student,
         {{ dbt_utils.surrogate_key(


### PR DESCRIPTION
For stg_ef3__staffs and stg_ef3__students, we're missing a `lower()` call on the alphanumeric id during skey generation. This leads to mismatching keys compared to reference calls (e.g. stuEdOrg or staffEdOrg).

It must be rare, given that it should be a fairly obvious data quality issue in the warehouse. But I've found cases of staff IDs with alphabetic letters in boston, which leads to mismatching ids and dbt test failures.

I'm not sure if this counts as "breaking" enough to hold for a major version bump @ejoranlienea 