### PR TITLE
Feature/Contacts and StudentContactAssociations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 ## New features
+- Add base/stage models for `contacts` and `student_contact_associations`, added due to the rename from parent to contact in Ed-Fi data standard v5.0.
+- Rename `k_parent` to `k_contact` in `stg_ef3__survey_responses`.
 ## Under the hood
+- Add columns to `base_ef3__parents` to allow data to be unioned into new `stg_ef3__contacts` model.
 ## Fixes
 
 # edu_edfi_source v0.3.6

--- a/macros/gen_skey.sql
+++ b/macros/gen_skey.sql
@@ -190,6 +190,11 @@
             'col_list': ['learningStandardId'],
             'annualize': True
         },
+        'k_contact': {
+            'reference_name': 'contact_reference',
+            'col_list': ['contactUniqueId'],
+            'annualize': False
+        },
 
         'k_template': {
             'reference_name': '',

--- a/models/staging/edfi_3/base/_edfi_3__base.yml
+++ b/models/staging/edfi_3/base/_edfi_3__base.yml
@@ -24,7 +24,6 @@ models:
   - name: base_ef3__contacts
     config:
       tags: ['core']
-      enabled: "{{ var('edu:contacts:enabled', False) }}"
   - name: base_ef3__course_offerings
     config:
       tags: ['core']
@@ -124,7 +123,6 @@ models:
   - name: base_ef3__student_contact_associations
     config:
       tags: ['core']
-      enabled: "{{ var('edu:contacts:enabled', False) }}"
   - name: base_ef3__student_discipline_incident_associations
     config:
       tags: ['discipline']

--- a/models/staging/edfi_3/base/_edfi_3__base.yml
+++ b/models/staging/edfi_3/base/_edfi_3__base.yml
@@ -21,6 +21,10 @@ models:
     config:
       tags: ['cohort']
       enabled: "{{ var('src:domain:cohort:enabled', True) }}"
+  - name: base_ef3__contacts
+    config:
+      tags: ['core']
+      enabled: "{{ var('edu:contacts:enabled', False) }}"
   - name: base_ef3__course_offerings
     config:
       tags: ['core']
@@ -117,6 +121,10 @@ models:
     config:
       tags: ['cohort']
       enabled: "{{ var('src:domain:cohort:enabled', True) }}"
+  - name: base_ef3__student_contact_associations
+    config:
+      tags: ['core']
+      enabled: "{{ var('edu:contacts:enabled', False) }}"
   - name: base_ef3__student_discipline_incident_associations
     config:
       tags: ['discipline']

--- a/models/staging/edfi_3/base/base_ef3__contacts.sql
+++ b/models/staging/edfi_3/base/base_ef3__contacts.sql
@@ -1,5 +1,5 @@
-with parents as (
-    {{ source_edfi3('parents') }}
+with contacts as (
+    {{ source_edfi3('contacts') }}
 ),
 renamed as (
     select
@@ -12,7 +12,7 @@ renamed as (
         is_deleted,
 
         v:id::string                                                                     as record_guid,
-        v:parentUniqueId::string                                                         as parent_unique_id,
+        v:contactUniqueId::string                                                        as contact_unique_id,
         v:personReference:personId::string                                               as person_id,
         v:firstName::string                                                              as first_name,
         v:middleName::string                                                             as middle_name,
@@ -40,6 +40,6 @@ renamed as (
 
         -- edfi extensions
         v:_ext as v_ext
-    from parents
+    from contacts
 )
 select * from renamed

--- a/models/staging/edfi_3/base/base_ef3__parents.sql
+++ b/models/staging/edfi_3/base/base_ef3__parents.sql
@@ -20,7 +20,9 @@ renamed as (
         v:maidenName::string                                                             as maiden_name,
         v:generationCodeSuffix::string                                                   as generation_code_suffix,
         v:personalTitlePrefix::string                                                    as personal_title_prefix,
-        v:genderIdentity::string                                                         as gender_identity,
+        -- the following three fields were introduced to the Contacts resource, which replaced Parents in v5.0
+        -- including them here (they will always be null) to allow the tables to be unioned in stage
+        v:genderIdentity::string                                                         as gender_identity, 
         v:preferredFirstName::string                                                     as preferred_first_name,
         v:preferredLastSurname::string                                                   as preferred_last_name,
         v:loginId::string                                                                as login_id,

--- a/models/staging/edfi_3/base/base_ef3__student_contact_associations.sql
+++ b/models/staging/edfi_3/base/base_ef3__student_contact_associations.sql
@@ -1,0 +1,30 @@
+with student_contact_associations as (
+    {{ source_edfi3('student_contact_associations') }}
+),
+renamed as (
+    select
+        tenant_code,
+        api_year,
+        pull_timestamp,
+        last_modified_timestamp,
+        file_row_number,
+        filename,
+        is_deleted,
+
+        v:id::string                                             as record_guid,
+        v:contactPriority::int                                   as contact_priority,
+        v:contactRestrictions::string                            as contact_restrictions,
+        v:emergencyContactStatus::boolean                        as is_emergency_contact,
+        v:livesWith::boolean                                     as is_living_with,
+        v:primaryContactStatus::boolean                          as is_primary_contact,
+        v:legalGuardian::boolean                                 as is_legal_guardian,
+        {{ extract_descriptor('v:relationDescriptor::string') }} as relation_type,
+        -- references
+        v:contactReference                                       as contact_reference,
+        v:studentReference                                       as student_reference,
+
+        -- edfi extensions
+        v:_ext as v_ext
+    from student_contact_associations
+)
+select * from renamed

--- a/models/staging/edfi_3/base/base_ef3__survey_responses.sql
+++ b/models/staging/edfi_3/base/base_ef3__survey_responses.sql
@@ -25,7 +25,7 @@ renamed as (
         v:surveyReference                               as survey_reference,
         v:studentReference                              as student_reference,
         v:staffReference                                as staff_reference,
-        coalesce(v:parentReference, v:contactReference) as contact_reference,
+        coalesce(v:parentReference, v:contactReference) as contact_reference, -- parentReference renamed to contactReference in Data Standard v5.0
         -- lists
         v:surveyLevels  as v_survey_levels,    
         -- edfi extensions

--- a/models/staging/edfi_3/base/base_ef3__survey_responses.sql
+++ b/models/staging/edfi_3/base/base_ef3__survey_responses.sql
@@ -22,10 +22,10 @@ renamed as (
         v:responseDate::date                                          as response_date, 
         v:responseTime::int                                           as completion_time_seconds, 
         --references
-        v:surveyReference    as survey_reference,
-        v:studentReference   as student_reference,
-        v:staffReference     as staff_reference,
-        v:parentReference    as parent_reference,
+        v:surveyReference                               as survey_reference,
+        v:studentReference                              as student_reference,
+        v:staffReference                                as staff_reference,
+        coalesce(v:parentReference, v:contactReference) as contact_reference,
         -- lists
         v:surveyLevels  as v_survey_levels,    
         -- edfi extensions

--- a/models/staging/edfi_3/stage/_edfi_3__stage.yml
+++ b/models/staging/edfi_3/stage/_edfi_3__stage.yml
@@ -13,6 +13,12 @@ referential_integrity_tests:
         field: k_cohort
         tags: [ 'ref_integrity' ]
 
+  - k_contact: &ref_k_contact
+    - relationships:
+        to: ref('stg_ef3__contacts')
+        field: k_contact
+        tags: [ 'ref_integrity' ]
+
   - k_course: &ref_k_course
     - relationships:
         to: ref('stg_ef3__courses')
@@ -199,6 +205,22 @@ models:
     config:
       tags: ['cohort']
       enabled: "{{ var('src:domain:cohort:enabled', True) }}"
+
+  - name: stg_ef3__contacts
+    config:
+      tags: ['core']
+
+  - name: stg_ef3__contacts__addresses
+    config:
+      tags: ['core']
+
+  - name: stg_ef3__contacts__emails
+    config:
+      tags: ['core']
+
+  - name: stg_ef3__contacts__telephones
+    config:
+      tags: ['core']
 
   - name: stg_ef3__course_offerings
     config:
@@ -618,6 +640,17 @@ models:
       - name: k_cohort
         tests:
           *ref_k_cohort
+
+  - name: stg_ef3__student_contact_associations
+    config:
+      tags: ['core']
+      columns:
+      - name: k_student
+        tests:
+          *ref_k_student
+      - name: k_contact
+        tests:
+          *ref_k_contact
 
   - name: stg_ef3__student_discipline_incident_behavior_associations
     config:

--- a/models/staging/edfi_3/stage/stg_ef3__contacts.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__contacts.sql
@@ -22,7 +22,7 @@ keyed as (
             ]
         ) }} as k_contact,
         unioned.*
-        {{ extract_extension([model_name=this.name, 'stg_ef3__parents'], flatten=True) }}
+        {{ extract_extension(model_name=[this.name, 'stg_ef3__parents'], flatten=True) }}
     from unioned
 ),
 deduped as (

--- a/models/staging/edfi_3/stage/stg_ef3__contacts.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__contacts.sql
@@ -1,0 +1,36 @@
+with base_contacts as (
+    select * from {{ ref('base_ef3__contacts') }}
+    where not is_deleted
+),
+base_parents as (
+    select * rename parent_unique_id as contact_unique_id
+    from {{ ref('base_ef3__parents') }}
+    where not is_deleted
+),
+unioned as (
+    select * from base_contacts
+    union 
+    select * from base_parents
+),
+keyed as (
+    select 
+        {{ dbt_utils.surrogate_key(
+            [
+                'tenant_code',
+                'lower(contact_unique_id)'
+            ]
+        ) }} as k_contact,
+        unioned.*
+        {{ extract_extension(model_name=this.name, flatten=True) }}
+    from unioned
+),
+deduped as (
+    {{
+        dbt_utils.deduplicate(
+            relation='keyed',
+            partition_by='k_contact', 
+            order_by='api_year desc, pull_timestamp desc'
+        )
+    }}
+)
+select * from deduped

--- a/models/staging/edfi_3/stage/stg_ef3__contacts.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__contacts.sql
@@ -22,7 +22,7 @@ keyed as (
             ]
         ) }} as k_contact,
         unioned.*
-        {{ extract_extension(model_name=this.name, flatten=True) }}
+        {{ extract_extension([model_name=this.name, 'stg_ef3__parents'], flatten=True) }}
     from unioned
 ),
 deduped as (

--- a/models/staging/edfi_3/stage/stg_ef3__contacts.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__contacts.sql
@@ -1,5 +1,3 @@
-{% if var("edu:contacts:enabled", False) %}
-
 with base_contacts as (
     select * from {{ ref('base_ef3__contacts') }}
     where not is_deleted
@@ -37,12 +35,3 @@ deduped as (
     }}
 )
 select * from deduped
-
-{% else %}
-
-select * rename 
-    k_parent as k_contact,
-    parent_unique_id as contact_unique_id
-from {{ ref('stg_ef3__parents') }}
-
-{% endif %}

--- a/models/staging/edfi_3/stage/stg_ef3__contacts.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__contacts.sql
@@ -7,6 +7,7 @@ base_parents as (
     from {{ ref('base_ef3__parents') }}
     where not is_deleted
 ),
+-- parents were renamed to contacts in Data Standard v5.0
 unioned as (
     select * from base_contacts
     union 

--- a/models/staging/edfi_3/stage/stg_ef3__contacts.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__contacts.sql
@@ -1,3 +1,5 @@
+{% if var("edu:contacts:enabled", False) %}
+
 with base_contacts as (
     select * from {{ ref('base_ef3__contacts') }}
     where not is_deleted
@@ -35,3 +37,12 @@ deduped as (
     }}
 )
 select * from deduped
+
+{% else %}
+
+select * rename 
+    k_parent as k_contact,
+    parent_unique_id as contact_unique_id
+from {{ ref('stg_ef3__parents') }}
+
+{% endif %}

--- a/models/staging/edfi_3/stage/stg_ef3__contacts__addresses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__contacts__addresses.sql
@@ -1,0 +1,1 @@
+{{ flatten_addresses('stg_ef3__contacts', ['k_contact']) }}

--- a/models/staging/edfi_3/stage/stg_ef3__contacts__emails.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__contacts__emails.sql
@@ -1,0 +1,1 @@
+{{ flatten_emails('stg_ef3__contacts', ['k_contact']) }}

--- a/models/staging/edfi_3/stage/stg_ef3__contacts__telephones.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__contacts__telephones.sql
@@ -1,0 +1,1 @@
+{{ flatten_telephones('stg_ef3__contacts', ['k_contact']) }}

--- a/models/staging/edfi_3/stage/stg_ef3__student_contact_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_contact_associations.sql
@@ -1,5 +1,3 @@
-{% if var("edu:contacts:enabled", False) %}
-
 with base_stu_contact as (
     select 
         *,
@@ -41,10 +39,3 @@ deduped as (
     }}
 )
 select * from deduped
-
-{% else %}
-
-select * rename k_parent as k_contact
-from {{ ref('stg_ef3__student_parent_associations') }}
-
-{% endif %}

--- a/models/staging/edfi_3/stage/stg_ef3__student_contact_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_contact_associations.sql
@@ -7,6 +7,7 @@ base_stu_parent as (
     from {{ ref('base_ef3__student_parent_associations') }}
     where not is_deleted
 ),
+-- parents were renamed to contacts in Data Standard v5.0
 unioned as (
     select * from base_stu_contact
     union 

--- a/models/staging/edfi_3/stage/stg_ef3__student_contact_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_contact_associations.sql
@@ -1,0 +1,34 @@
+with base_stu_contact as (
+    select * from {{ ref('base_ef3__student_contact_associations') }}
+    where not is_deleted
+),
+base_stu_parent as (
+    select * rename parent_reference as contact_reference
+    from {{ ref('base_ef3__student_parent_associations') }}
+    where not is_deleted
+),
+unioned as (
+    select * from base_stu_contact
+    union 
+    select * from base_stu_parent
+),
+keyed as (
+    select 
+        {{ gen_skey('k_student') }},
+        {{ gen_skey('k_contact') }},
+        {{ gen_skey('k_student_xyear') }},
+        api_year as school_year,
+        unioned.*
+        {{ extract_extension(model_name=this.name, flatten=True) }}
+    from unioned
+),
+deduped as (
+    {{
+        dbt_utils.deduplicate(
+            relation='keyed',
+            partition_by='k_student, k_contact',
+            order_by='pull_timestamp desc'
+        )
+    }}
+)
+select * from deduped

--- a/models/staging/edfi_3/stage/stg_ef3__student_contact_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_contact_associations.sql
@@ -26,7 +26,7 @@ keyed as (
         {{ gen_skey('k_student_xyear') }},
         api_year as school_year,
         unioned.*
-        {{ extract_extension(model_name=this.name, flatten=True) }}
+        {{ extract_extension(model_name=[this.name, 'stg_ef3__student_parent_associations'], flatten=True) }}
     from unioned
 ),
 deduped as (

--- a/models/staging/edfi_3/stage/stg_ef3__student_contact_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_contact_associations.sql
@@ -22,11 +22,7 @@ keyed as (
     select 
         {{ gen_skey('k_student') }},
         -- we can't use the gen_skey macro here because we're bringing in the deprecated parents endpoint data, which contains a parentReference that won't work
-        iff(
-            contact_unique_id is not null, 
-            md5(cast(coalesce(cast(tenant_code as TEXT), '') || '-' || coalesce(cast(lower(contact_unique_id) as TEXT), '') as TEXT)), 
-            null
-        )::varchar(32) as k_contact,
+        {{ dbt_utils.surrogate_key(['tenant_code', 'contact_unique_id']) }} as k_contact,
         {{ gen_skey('k_student_xyear') }},
         api_year as school_year,
         unioned.*

--- a/models/staging/edfi_3/stage/stg_ef3__student_contact_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_contact_associations.sql
@@ -1,3 +1,5 @@
+{% if var("edu:contacts:enabled", False) %}
+
 with base_stu_contact as (
     select 
         *,
@@ -39,3 +41,10 @@ deduped as (
     }}
 )
 select * from deduped
+
+{% else %}
+
+select * rename k_parent as k_contact
+from {{ ref('stg_ef3__student_parent_associations') }}
+
+{% endif %}

--- a/models/staging/edfi_3/stage/stg_ef3__survey_responses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__survey_responses.sql
@@ -15,7 +15,7 @@ keyed as (
         {{ gen_skey('k_survey') }},
         {{ gen_skey('k_staff') }},
         {{ gen_skey('k_student') }},
-        {{ gen_skey('k_parent') }},
+        {{ gen_skey('k_contact') }},
         base_survey_responses.*
         {{ extract_extension(model_name=this.name, flatten=True) }}
     from base_survey_responses


### PR DESCRIPTION
## Description & motivation
In Data Standard v5.0, Parents were renamed to Contacts. The new Contact entity is identical to the previous Parent entity with the addition of an optional GenderIdentity, PreferredFirstName, and PreferredLastName fields. StudentParentAssociations was also renamed to StudentContactAssociations and the parentReference in SurveyResponses was renamed to contactReference.

This PR adds base and stage models for the new resources, which union in the data from the deprecated parent-named resources.

## Breaking changes introduced by this PR:
- `stg_ef3__survey_responses` now includes `k_contact` instead of `k_parent`.
- Three new columns were added to the base and stage models for parents. These will always be null for parents but may be populated in contacts, so they are required for the union operation.

## PR Merge Priority:
- Medium

## Changes to existing files:
- `gen_skey` : add `k_contact` to key definitions
- `base_ef3__parents` : add three new fields which were introduced along with the Contacts rename in order to allow the tables to be unioned in stage
- `base_ef3__survey_responses` : coalesce parentReference and contactReference into a single `contact_reference`
- `stg_ef3__survey_responses` : rename k_parent to k_contact

## New files created:
Base and stage models for `contacts`, `student_contact_associations`, and unpacked `contacts` lists.

## Tests and QC done:
Ran in Stadium SCDE; confirmed that columns were populating correctly (where data is available) and staging tables included both Parent and Contact data. 

## Future ToDos & Questions:
- I think the impact of the switching to `k_contact` in `stg_ef3__survey_responses` is small, possibly none - we don't have any warehouse models for surveys yet and I didn't see the field referenced in any implementation repos.