### PR TITLE
Bugfix/Updated Surrogate Keys to include lower() in student_unique_id inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## New features
 ## Under the hood
 ## Fixes
+- Fix surrogate key creation for `stg_ef3__student_academic_records`, `stg_ef3__student_objective_assessments`, and `stg_ef3__students` to properly handle lowering of alphanumeric columns that are part of natural keys
 
 # edu_edfi_source v0.3.6
 ## Fixes

--- a/models/staging/edfi_3/stage/stg_ef3__student_academic_records.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_academic_records.sql
@@ -9,7 +9,7 @@ keyed as (
                 'tenant_code',
                 'ed_org_id',
                 'school_year',
-                'student_unique_id',
+                'lower(student_unique_id)',
                 'lower(academic_term)'
             ]
         ) }} as k_student_academic_record,

--- a/models/staging/edfi_3/stage/stg_ef3__student_objective_assessments.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_objective_assessments.sql
@@ -42,8 +42,8 @@ keyed as (
             ['tenant_code',
             'api_year',
             'lower(academic_subject)',
-            'student_assessment_identifier',
-            'objective_assessment_identification_code']
+            'lower(student_assessment_identifier)',
+            'lower(objective_assessment_identification_code)']
         ) }} as k_student_objective_assessment,
         {{ gen_skey('k_objective_assessment', extras = ['academic_subject']) }},
         k_student_assessment,

--- a/models/staging/edfi_3/stage/stg_ef3__students.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__students.sql
@@ -15,7 +15,7 @@ keyed as (
         {{ dbt_utils.surrogate_key(
             [
                 'tenant_code',
-                'student_unique_id'
+                'lower(student_unique_id)'
             ]
         ) }} as k_student_xyear,
         base_students.*


### PR DESCRIPTION
## Description & motivation
Updated any chases where we use dbt's surrogate key macro with `student_unique_id` inputs to include a `lower()` function. This change ensures consistent key behavior across our models, aligning the macro's output with our gen_key function, which automatically lowers all inputs.

## Context of issue

> _Issue:_ 
>- I am having some test failures in stadium. I am looking through them to figure out what the issues are, but one of them in particular is an odd failure due to how keys are built in edu_edfi_source:

> _Test Logic:_ 
>- Every `k_student_academic_record` value in `stg_ef3__course_transcripts` should have a matching value in `stg_ef3__student_academic_records`.

> _Reason behind failure:_
>- Some keys in `stg_ef3__course_transcripts` are not found within `stg_ef3__student_academic_records` even when the actual row does exist. This is happening because the key generation logic between the two models is different, even when they take the same input columns.
>- `stg_ef3__student_academic_records` generates `k_student_academic_record` through dbt's gen surrogate key macro [here](https://github.com/edanalytics/edu_edfi_source/blob/main/models/staging/edfi_3/stage/stg_ef3__student_academic_records.sql#L7-L15). Inherently, dbt's macro takes into account a col's original casing, meaning using the macro on a value "A" will yield a different key than using it on a value "a".
>- `stg_ef3__course_transcripts` generates the same key using EA's gen_key macro [here](https://github.com/edanalytics/edu_edfi_source/blob/main/models/staging/edfi_3/stage/stg_ef3__course_transcripts.sql#L8). This macro lowers [all columns inputted](https://github.com/edanalytics/edu_edfi_source/blob/main/macros/gen_skey.sql#L97-L103).
>- So even when we have the same input values, the resulting key is different and the test fails.

