### PR TITLE
New DS5 optional fields for `Section`, `CourseTranscript`, and `StudentSectionAssociation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 ## New features
+- Add `section_type` descriptor column to `sections` (Ed-Fi Data Standard v5.0 addition)
+- Add `responsible_teacher_staff_reference`, `v_programs`, `v_sections` columns to `course_transcripts` (Ed-Fi Data Standard v5.0 additions)
+- Add `v_programs` column to `course_transcripts` (Ed-Fi Data Standard v5.0 addition)
 ## Under the hood
 ## Fixes
 

--- a/models/staging/edfi_3/base/base_ef3__course_transcripts.sql
+++ b/models/staging/edfi_3/base/base_ef3__course_transcripts.sql
@@ -42,11 +42,14 @@ renamed as (
         v:courseReference                        as course_reference,
         v:studentAcademicRecordReference         as student_academic_record_reference,
         v:externalEducationOrganizationReference as external_education_organization_reference,
+        v:responsibleTeacherStaffReference       as responsible_teacher_staff_reference,
 				-- non-identity collection components
 				v:earnedAdditionalCredits              as v_earned_additional_credits,
         v:academicSubjects                     as v_academic_subjects,
         v:alternativeCourseIdentificationCodes as v_alternative_course_identification_codes,
         v:creditCategories                     as v_credit_categories,
+        v:coursePrograms                       as v_programs,
+        v:sections                             as v_sections,
 
         -- edfi extensions
         v:_ext as v_ext

--- a/models/staging/edfi_3/base/base_ef3__sections.sql
+++ b/models/staging/edfi_3/base/base_ef3__sections.sql
@@ -32,6 +32,7 @@ renamed as (
         {{ extract_descriptor('v:availableCreditTypeDescriptor::string') }}    as available_credit_type,
         {{ extract_descriptor('v:educationalEnvironmentDescriptor::string') }} as educational_environment_type,
         {{ extract_descriptor('v:instructionLanguageDescriptor::string') }}    as instruction_language,
+        {{ extract_descriptor('v:sectionTypeDescriptor::string') }}            as section_type,
         {{ extract_descriptor('v:mediumOfInstructionDescriptor::string') }}    as medium_of_instruction,
         {{ extract_descriptor('v:populationServedDescriptor::string') }}       as population_served,
         -- references

--- a/models/staging/edfi_3/base/base_ef3__sections.sql
+++ b/models/staging/edfi_3/base/base_ef3__sections.sql
@@ -32,9 +32,9 @@ renamed as (
         {{ extract_descriptor('v:availableCreditTypeDescriptor::string') }}    as available_credit_type,
         {{ extract_descriptor('v:educationalEnvironmentDescriptor::string') }} as educational_environment_type,
         {{ extract_descriptor('v:instructionLanguageDescriptor::string') }}    as instruction_language,
-        {{ extract_descriptor('v:sectionTypeDescriptor::string') }}            as section_type,
         {{ extract_descriptor('v:mediumOfInstructionDescriptor::string') }}    as medium_of_instruction,
         {{ extract_descriptor('v:populationServedDescriptor::string') }}       as population_served,
+        {{ extract_descriptor('v:sectionTypeDescriptor::string') }}            as section_type,
         -- references
         v:courseOfferingReference as course_offering_reference,
         v:locationReference       as location_reference,

--- a/models/staging/edfi_3/base/base_ef3__student_section_associations.sql
+++ b/models/staging/edfi_3/base/base_ef3__student_section_associations.sql
@@ -28,6 +28,9 @@ renamed as (
         v:studentReference as student_reference,
         v:sectionReference as section_reference,
 
+        -- lists
+        v:programs as v_programs,
+
         -- edfi extensions
         v:_ext as v_ext
     from student_section


### PR DESCRIPTION
## Description & motivation
Pertaining to [this Monday item](https://educationanalytics.monday.com/boards/6573916906/pulses/6575119303) and this [EDU PR](https://github.com/edanalytics/edu_wh/pull/150)

Data Standard v5.0 adds some optional fields pertaining to courses. This PR adds these to the base model.

## Breaking changes introduced by this PR:
None

## PR Merge Priority:
- Low

## Changes to existing files:
- base_ef3__course_transcripts
  - add `responsible_teacher_staff_reference`, `v_programs`, and `v_sections`
- base_ef3__sections
  - add `section_type`
- base_ef3__student_section_associations
  - add `v_programs`

## Tests and QC done:
Ran in Stadium SCDE; confirmed that columns appeared, but these fields are not populated anywhere yet