### PR TITLE
feature/StudentAssessmentEducationOrg

### DIFF
--- a/macros/gen_skey.sql
+++ b/macros/gen_skey.sql
@@ -210,6 +210,17 @@
             'annualize': False
         },
 
+         'k_student_assessment': {
+            'reference_name': 'studentAssessmentReference'.
+            'col_list': [
+                'assessmentIdentifier',
+                'namespace',
+                'studentAssessmentIdentifier',
+                'studentUniqueId'
+            ],
+            'annualize': True
+
+
     }
     %}
     {#- retrieve key def for then decompose parts -#}

--- a/macros/gen_skey.sql
+++ b/macros/gen_skey.sql
@@ -219,9 +219,9 @@
                 'studentUniqueId'
             ],
             'annualize': True
-
-
+        }
     }
+    
     %}
     {#- retrieve key def for then decompose parts -#}
     {% set skey_def = skey_defs[k_name] %}

--- a/models/staging/edfi_3/base/_edfi_3__base.yml
+++ b/models/staging/edfi_3/base/_edfi_3__base.yml
@@ -191,3 +191,6 @@ models:
     config:
       tags: ['survey']
       enabled: "{{ var('src:program:survey:enabled', True) }}"
+  - name: base_ef3__student_assessment_education_organizations
+    config:
+      tags: ['core']

--- a/models/staging/edfi_3/base/base_ef3__student_assessment_education_organizations.sql
+++ b/models/staging/edfi_3/base/base_ef3__student_assessment_education_organizations.sql
@@ -1,0 +1,38 @@
+with student_assessment_education_organizations as (
+    select * from {{ source_edfi3('student_assessment_education_organizations') }}
+),
+
+
+renamed as (
+    select
+        tenant_code,
+        api_year,
+        pull_timestamp,
+        last_modified_timestamp,
+        file_row_number,
+        filename,
+        is_deleted,
+        v:id::string                                                                            as record_guid,
+        v:educationOrganizationReference:educationOrganizationId::int                           as ed_org_identifier,
+        v:educationOrganizationReference:link:rel::string                                       as ed_org_type,
+        {{ extract_descriptor('v:educationOrganizationAssociationTypeDescriptor::string') }}    as ed_org_association_type,
+        v:schoolYearTypeReference:schoolYear::int                                               as school_year,
+        v:studentAssessmentReference:assessmentIdentifier::string                               as assement_identifier,
+        v:studentAssessmentReference:namespace::string                                          as assessment_name_space,
+        v:studentAssessmentReference:studentAssessmentIdentifier::string                        as student_assessment_identifier,
+        v:studentAssessmentReference:studentUniqueId::string                                    as student_id,
+        -- references
+        v:educationOrganizationReference                                                        as education_organization_reference,
+        v:studentAssessmentReference                                                            as student_assessment_reference
+        -- edfi extensions
+        v:_ext                                                                                  as v_ext
+    from student_assessment_education_organizations
+)
+
+
+select  * from renamed
+
+
+
+
+

--- a/models/staging/edfi_3/stage/_edfi_3__stage.yml
+++ b/models/staging/edfi_3/stage/_edfi_3__stage.yml
@@ -131,6 +131,13 @@ referential_integrity_tests:
         field: k_survey_response
         tags: ['ref_integrity']
 
+  - k_student_assessment: &ref_k_student_assessment
+    - relationships:
+        to: ref('stg_ef3__student_assessment')
+        field: k_student_assessment
+        tags: ['ref_integrity']
+
+
 
 models:
   - name: stg_ef3__assessments
@@ -878,3 +885,11 @@ models:
     config: 
       tags: ['survey']
       enabled: "{{ var('src:domain:survey:enabled', True) }}"
+  
+  - name: stg_ef3__student_assessment_education_organizations
+    config:
+      tags: ['assessment']
+    columns:
+      - name: k_student_assessment
+        tests:
+          *ref_k_student_assessment

--- a/models/staging/edfi_3/stage/stg_ef3__student_assessment_education_organizations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_assessment_education_organizations.sql
@@ -1,0 +1,39 @@
+with base as (
+    select * from {{ ref('base_ef3__student_assessment_education_organizations') }}
+    where not is_deleted
+),
+
+
+keyed as (
+    select
+        {{
+            dbt_utils.generate_surrogate_key(
+                [   'tenant_code',
+                    'api_year',
+                    'ed_org_identifier',
+                    'ed_org_association_type',
+                    'assessment_identifier',
+                    'student_assessment_identifier',
+                    'student_unique_id',
+                    'lower(namespace)'
+                ]
+            )
+        }} as k_student_assessment_ed_org,
+        {{ gen_skey('k_ed_org') }},
+        {{ gen_skey('k_student_assessment') }}
+    from base
+),
+
+
+deduped as (
+    {{
+        dbt_utils.deduplicate(
+            relation = 'keyed',
+            partition_by = 'k_student_assessment_ed_org',
+            order_by = 'pull_timestamp desc'
+        )
+    }}
+)
+
+
+select * from deduped


### PR DESCRIPTION
From this [Monday item](https://educationanalytics.monday.com/boards/6574606992/pulses/6574610173)
This PR supports this feature by adding a new `base` and `stg` model for the `StudentAssessmentEducationOrganizations` entity.

## PR Merge Priority:
<!---
This checklist helps the reviewers understand the level of priority for merging this PR.
A loose description of merging priority levels is:
Low: A week or more.
Medium: Within 3 days or less.
High: As soon as possible.
-->
- [x] Low 
- [ ] Medium
- [ ] High

<!---
If High Priority, explain why as a comment below.
-->

## New files:
- `base_ef3__student_assessment_education_organizations.sql`
- `stg_ef3__student_assessment_education_organizations.sql`

## Changes to existing files:
- `gen_skey.sql` : Update `skey_defs` with `StudentAssessment` reference 
- `_edfi_3__base.yml`: Configure new base model
- `_edfi_3__stage.yml`: Configure new stg model + tests
