### PR TITLE
Fix/coalesce obj assess subjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## New features
 ## Under the hood
 ## Fixes
+- Fix coalesce logic for academic subjects in `stg_ef3__objective_assessments` and `stg_ef3__student_objective_assessments` to hydrate correctly when populated in respective Ed-Fi element's `academicSubject` field
 
 # edu_edfi_source v0.4.3
 ## Fixes

--- a/models/staging/edfi_3/stage/stg_ef3__objective_assessments.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__objective_assessments.sql
@@ -21,7 +21,8 @@ distinct_obj_subject as (
 join_subject as (
     select
         base_obj_assessments.*,
-        distinct_obj_subject.academic_subject
+        -- prefer subject directly from obj assessment, else use studentAssess value
+        coalesce(base_obj_assessments.academic_subject_descriptor, distinct_obj_subject.academic_subject) as academic_subject
     from base_obj_assessments
     -- this join will drop objective assessments with no student results
     join distinct_obj_subject 

--- a/models/staging/edfi_3/stage/stg_ef3__student_objective_assessments.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_objective_assessments.sql
@@ -1,6 +1,9 @@
 with stage_student_assessments as (
     select * from {{ ref('stg_ef3__student_assessments') }}
 ),
+stage_obj_assessments as (
+    select * from {{ ref('stg_ef3__objective_assessments') }}
+),
 flattened as (
     select
         tenant_code,
@@ -32,6 +35,19 @@ flattened as (
         value:scoreResults as v_score_results
     from stage_student_assessments,
         lateral flatten(input => v_student_objective_assessments)
+),
+-- join to get subject from stg obj assess (if not null)
+joined as (
+    select
+      flattened.* exclude(academic_subject),
+      coalesce(stage_obj_assessments.academic_subject, flattened.academic_subject) as academic_subject
+    from flattened
+    join stage_obj_assessments
+      on flattened.tenant_code = stage_obj_assessments.tenant_code
+      and flattened.api_year = stage_obj_assessments.api_year
+      and flattened.assessment_identifier = stage_obj_assessments.assessment_identifier
+      and flattened.namespace = stage_obj_assessments.namespace
+      and flattened.objective_assessment_identification_code = stage_obj_assessments.objective_assessment_identification_code
 ),
 keyed as (
     select
@@ -69,7 +85,7 @@ keyed as (
         when_assessed_grade_level,
         v_performance_levels,
         v_score_results
-    from flattened
+    from joined
 ),
 -- todo: we already dedupe in student assessments so this is actually only necessary if we think there
     -- could be dupes in the objective assessments list


### PR DESCRIPTION
This PR updates the logic for `stg_ef3__objective_assessments` and `stg_ef3__student_objective_assessments` to correctly coalesce `academic_subject`, preferring the subject value that comes from the `objectiveAssessment` object in Ed-Fi, and if null, falling back to the original logic (take from `stg_ef3__student_assessment.academic_subject`).

This will have no impact on objective assessments that are missing `academic_subject` (very common), but will allow for more precise subject matching in cases  where it has been populated in `objectiveAssessment` (e.g., the new ACT bundles that EA has been developing, which have many subscores of different subjects).


This has been tested locally in Texas, showing correct values in dim_objective_assessment:
![image](https://github.com/user-attachments/assets/7ee83c54-8600-45b7-9673-33cecfa9b49c)

