### PR TITLE
Bugfix/student objective assessment key

### DIFF
--- a/models/staging/edfi_3/stage/stg_ef3__student_objective_assessments.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_objective_assessments.sql
@@ -58,6 +58,8 @@ keyed as (
             ['tenant_code',
             'api_year',
             'lower(academic_subject)',
+            'lower(assessment_identifier)',
+            'lower(namespace)',
             'lower(student_assessment_identifier)',
             'lower(objective_assessment_identification_code)']
         ) }} as k_student_objective_assessment,

--- a/models/staging/edfi_3/stage/stg_ef3__student_objective_assessments.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_objective_assessments.sql
@@ -60,8 +60,8 @@ keyed as (
             'lower(academic_subject)',
             'lower(assessment_identifier)',
             'lower(namespace)',
-            'lower(student_assessment_identifier)',
-            'lower(objective_assessment_identification_code)']
+            'lower(objective_assessment_identification_code)',
+            'lower(student_assessment_identifier)']
         ) }} as k_student_objective_assessment,
         {{ gen_skey('k_objective_assessment', extras = ['academic_subject']) }},
         k_student_assessment,


### PR DESCRIPTION
Fixes an edge case in the `student_objective_assessment` stage model that occurs when the same assessment has been loaded with different assessment identifiers. `assessment_identifier` was not previously part of the key, resulting in only the more recent record being preserved. 

Tested in SC, where most of the `NWEA-Map` records had also been loaded later as `MAP_Growth_subject`. Confirmed that this fix allowed all 11.7M affected records to be included in the table, matching the total Erik found in `dev_analytics.dev_ej_qc.stu_obj_assess_problem`.