### PR TITLE
Bugfix/obj assess k assess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## New features
 ## Under the hood
 ## Fixes
+- Fix unique key of `k_assessment` in `stg_ef3__objective_assessments`
 
 # edu_edfi_source v0.4.6
 ## Fixes

--- a/models/staging/edfi_3/stage/stg_ef3__objective_assessments.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__objective_assessments.sql
@@ -20,8 +20,9 @@ distinct_obj_subject as (
 join_subject as (
     select
         base_obj_assessments.*,
+        distinct_obj_subject.academic_subject as academic_subject,
         -- prefer subject directly from obj assessment, else use studentAssess value
-        coalesce(base_obj_assessments.academic_subject_descriptor, distinct_obj_subject.academic_subject) as academic_subject
+        coalesce(base_obj_assessments.academic_subject_descriptor, distinct_obj_subject.academic_subject) as obj_assess_academic_subject
     from base_obj_assessments
     -- this join will drop objective assessments with no student results
     join distinct_obj_subject 
@@ -36,7 +37,7 @@ keyed as (
         {{ dbt_utils.generate_surrogate_key(
             ['tenant_code',
             'api_year',
-            'lower(academic_subject)',
+            'lower(obj_assess_academic_subject)',
             'lower(assessment_identifier)',
             'lower(namespace)',
             'lower(objective_assessment_identification_code)']

--- a/models/staging/edfi_3/stage/stg_ef3__objective_assessments.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__objective_assessments.sql
@@ -38,9 +38,9 @@ keyed as (
             ['tenant_code',
             'api_year',
             'lower(academic_subject)',
-            'lower(obj_assess_academic_subject)',
             'lower(assessment_identifier)',
             'lower(namespace)',
+            'lower(obj_assess_academic_subject)',
             'lower(objective_assessment_identification_code)']
         ) }} as k_objective_assessment,
         {{ gen_skey('k_assessment', extras = ['academic_subject']) }},

--- a/models/staging/edfi_3/stage/stg_ef3__objective_assessments.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__objective_assessments.sql
@@ -37,6 +37,7 @@ keyed as (
         {{ dbt_utils.generate_surrogate_key(
             ['tenant_code',
             'api_year',
+            'lower(academic_subject)',
             'lower(obj_assess_academic_subject)',
             'lower(assessment_identifier)',
             'lower(namespace)',

--- a/models/staging/edfi_3/stage/stg_ef3__objective_assessments.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__objective_assessments.sql
@@ -57,6 +57,12 @@ deduped as (
             order_by='last_modified_timestamp desc, pull_timestamp desc'
         )
     }}
+),
+{# Rename obj_assess_academic_subject --> academic_subject for human-readability and to avoid breaking change to warehouse. academic_subject above represents 'OVERALL' assessment subject, so that the gen_skey() call works. #}
+renamed as (
+  select 
+    deduped.* RENAME (academic_subject as assess_academic_subject, obj_assess_academic_subject as academic_subject)
+  from deduped
 )
-select * from deduped
+select * from renamed
 where not is_deleted

--- a/models/staging/edfi_3/stage/stg_ef3__student_objective_assessments.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_objective_assessments.sql
@@ -41,7 +41,7 @@ flattened as (
 joined as (
     select
       flattened.* exclude(academic_subject),
-      coalesce(stage_obj_assessments.obj_assess_academic_subject, flattened.academic_subject) as academic_subject
+      coalesce(stage_obj_assessments.academic_subject, flattened.academic_subject) as academic_subject
     from flattened
     join stage_obj_assessments
       on flattened.tenant_code = stage_obj_assessments.tenant_code

--- a/models/staging/edfi_3/stage/stg_ef3__student_objective_assessments.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_objective_assessments.sql
@@ -41,7 +41,7 @@ flattened as (
 joined as (
     select
       flattened.* exclude(academic_subject),
-      coalesce(stage_obj_assessments.academic_subject, flattened.academic_subject) as academic_subject
+      coalesce(stage_obj_assessments.obj_assess_academic_subject, flattened.academic_subject) as academic_subject
     from flattened
     join stage_obj_assessments
       on flattened.tenant_code = stage_obj_assessments.tenant_code


### PR DESCRIPTION
This fixes a bug recently introduce here - https://github.com/edanalytics/edu_edfi_source/pull/117
The foreign key generation for `k_assessment` within `objective_assessments` is using the wrong value for academic subject. This only impacts cases where objective assessment subject exists and is NOT equal to overall assessment subject.

This branch corrects the subject used for k_assessment, but also brings forward both values for subject, so the right one can be used in stg_ef3__student_objective_assessments as well