### PR TITLE
Feature/incremental large stg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 ## New features
+ - Add (optional) support for incremental materialization of most expensive stg models
 ## Under the hood
 ## Fixes
 

--- a/macros/stg_post_hook_delete.sql
+++ b/macros/stg_post_hook_delete.sql
@@ -1,0 +1,5 @@
+{% macro stg_post_hook_delete() %}
+{% if is_incremental() %}
+    DELETE FROM {{ this }} WHERE is_deleted;
+{% endif %}
+{% endmacro %}

--- a/models/staging/edfi_3/intermediate/int_ef3__student_assessments__identify_subject.sql
+++ b/models/staging/edfi_3/intermediate/int_ef3__student_assessments__identify_subject.sql
@@ -2,7 +2,7 @@ with base_stu_assessments as (
     select * from {{ ref('base_ef3__student_assessments') }}
     {% if var('edu:edfi_source:large_stg_materialization', 'table') == 'incremental' %}
     -- Only get new or updated records since the last run
-    where last_modified_timestamp > (select max(pull_timestamp) from {{ this }})
+    where last_modified_timestamp > (select max(pull_timestamp) from {{ ref('stg_ef3__student_assessments') }})
     {% endif %}
 ),
 stg_assessments_single_subj as (

--- a/models/staging/edfi_3/intermediate/int_ef3__student_assessments__identify_subject.sql
+++ b/models/staging/edfi_3/intermediate/int_ef3__student_assessments__identify_subject.sql
@@ -1,5 +1,9 @@
 with base_stu_assessments as (
     select * from {{ ref('base_ef3__student_assessments') }}
+    {% if is_incremental() %}
+    -- Only get new or updated records since the last run
+    where last_modified_timestamp > (select max(pull_timestamp) from {{ this }})
+    {% endif %}
 ),
 stg_assessments_single_subj as (
     select

--- a/models/staging/edfi_3/intermediate/int_ef3__student_assessments__identify_subject.sql
+++ b/models/staging/edfi_3/intermediate/int_ef3__student_assessments__identify_subject.sql
@@ -1,9 +1,5 @@
 with base_stu_assessments as (
     select * from {{ ref('base_ef3__student_assessments') }}
-    {% if var('edu:edfi_source:large_stg_materialization', 'table') == 'incremental' %}
-    -- Only get new or updated records since the last run
-    where last_modified_timestamp > (select max(pull_timestamp) from {{ ref('stg_ef3__student_assessments') }})
-    {% endif %}
 ),
 stg_assessments_single_subj as (
     select

--- a/models/staging/edfi_3/intermediate/int_ef3__student_assessments__identify_subject.sql
+++ b/models/staging/edfi_3/intermediate/int_ef3__student_assessments__identify_subject.sql
@@ -1,6 +1,6 @@
 with base_stu_assessments as (
     select * from {{ ref('base_ef3__student_assessments') }}
-    {% if is_incremental() %}
+    {% if var('edu:edfi_source:large_stg_materialization', 'table') == 'incremental' %}
     -- Only get new or updated records since the last run
     where last_modified_timestamp > (select max(pull_timestamp) from {{ this }})
     {% endif %}

--- a/models/staging/edfi_3/stage/stg_ef3__course_transcripts.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__course_transcripts.sql
@@ -29,4 +29,7 @@ deduped as (
     }}
 )
 select * from deduped
+{% if not is_incremental() %}
 where not is_deleted
+{% endif %}
+

--- a/models/staging/edfi_3/stage/stg_ef3__course_transcripts.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__course_transcripts.sql
@@ -1,5 +1,5 @@
 {{ config(
-    materialized='incremental',
+    materialized=var('edu:edfi_source:large_stg_materialization', 'table'),
     unique_key=['k_course', 'k_student_academic_record', 'course_attempt_result'],
     post_hook=["{{edu_edfi_source.stg_post_hook_delete()}}"]
 ) }}

--- a/models/staging/edfi_3/stage/stg_ef3__grades.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__grades.sql
@@ -1,5 +1,5 @@
 {{ config(
-    materialized='incremental',
+    materialized=var('edu:edfi_source:large_stg_materialization', 'table'),
     unique_key=['k_grading_period', 'k_student', 'k_school', 'k_course_section', 'grade_type'],
     post_hook=["{{edu_edfi_source.stg_post_hook_delete()}}"]
 ) }}

--- a/models/staging/edfi_3/stage/stg_ef3__grades.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__grades.sql
@@ -31,5 +31,7 @@ deduped as (
     }}
 )
 select * from deduped
+{% if not is_incremental() %}
 where not is_deleted
+{% endif %}
 order by tenant_code, school_year desc, student_unique_id

--- a/models/staging/edfi_3/stage/stg_ef3__schools.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__schools.sql
@@ -38,7 +38,11 @@ deduped_within_year as (
 ),
 -- .. then remove deletes as they shouldn't be used in x-year dedupe
 deduped_within_year_no_deletes as (
-    select * from deduped_within_year where not is_deleted
+    select * from deduped_within_year 
+    {% if not is_incremental() %}
+    where not is_deleted
+    {% endif %}
+
 ),
 -- .. and then dedupe across years to enforce the correct grain, keeping latest year that wasn't deleted
 deduped_across_years as (

--- a/models/staging/edfi_3/stage/stg_ef3__schools.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__schools.sql
@@ -1,5 +1,15 @@
+{{ config(
+    materialized='incremental',
+    unique_key='k_school',
+    post_hook=["{{edu_edfi_source.stg_post_hook_delete()}}"]
+) }}
 with base_schools as (
     select * from {{ ref('base_ef3__schools') }}
+
+    {% if is_incremental() %}
+    -- Only get newly added or deleted records since the last run
+    where last_modified_timestamp > (select max(last_modified_timestamp) from {{ this }})
+    {% endif %}
 ),
 keyed as (
     select 

--- a/models/staging/edfi_3/stage/stg_ef3__schools.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__schools.sql
@@ -1,5 +1,5 @@
 {{ config(
-    materialized='incremental',
+    materialized=var('edu:edfi_source:large_stg_materialization', 'table'),
     unique_key='k_school',
     post_hook=["{{edu_edfi_source.stg_post_hook_delete()}}"]
 ) }}

--- a/models/staging/edfi_3/stage/stg_ef3__student_academic_records.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_academic_records.sql
@@ -1,5 +1,15 @@
+{{ config(
+    materialized='incremental',
+    unique_key=['k_student_academic_record'],
+    post_hook=["{{edu_edfi_source.stg_post_hook_delete()}}"]
+) }}
 with base_academic_records as (
     select * from {{ ref('base_ef3__student_academic_records') }}
+
+    {% if is_incremental() %}
+    -- Only get newly added or deleted records since the last run
+    where last_modified_timestamp > (select max(last_modified_timestamp) from {{ this }})
+    {% endif %}
 ),
 keyed as (
     select 

--- a/models/staging/edfi_3/stage/stg_ef3__student_academic_records.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_academic_records.sql
@@ -39,4 +39,7 @@ deduped as (
     }}
 )
 select * from deduped
+{% if not is_incremental() %}
 where not is_deleted
+{% endif %}
+

--- a/models/staging/edfi_3/stage/stg_ef3__student_academic_records.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_academic_records.sql
@@ -1,5 +1,5 @@
 {{ config(
-    materialized='incremental',
+    materialized=var('edu:edfi_source:large_stg_materialization', 'table'),
     unique_key=['k_student_academic_record'],
     post_hook=["{{edu_edfi_source.stg_post_hook_delete()}}"]
 ) }}

--- a/models/staging/edfi_3/stage/stg_ef3__student_assessments.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_assessments.sql
@@ -7,7 +7,7 @@ with int_stu_assessments as (
 
     {% if is_incremental() %}
     -- Only get new or updated records since the last run
-    and last_modified_timestamp > (select max(pull_timestamp) from {{ this }})
+    where last_modified_timestamp > (select max(pull_timestamp) from {{ this }})
     {% endif %}
 ),
 keyed as (

--- a/models/staging/edfi_3/stage/stg_ef3__student_assessments.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_assessments.sql
@@ -1,6 +1,7 @@
 {{ config(
-    materialized='incremental',
-    unique_key=['k_student_assessment']
+    materialized=var('edu:edfi_source:large_stg_materialization', 'table'),
+    unique_key=['k_student_assessment'],
+    post_hook=["{{edu_edfi_source.stg_post_hook_delete()}}"]
 ) }}
 with int_stu_assessments as (
     select * from {{ ref('int_ef3__student_assessments__identify_subject') }}

--- a/models/staging/edfi_3/stage/stg_ef3__student_assessments.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_assessments.sql
@@ -39,4 +39,6 @@ deduped as (
     }}
 )
 select * from deduped
+{% if not is_incremental() %}
 where not is_deleted
+{% endif %}

--- a/models/staging/edfi_3/stage/stg_ef3__student_assessments.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_assessments.sql
@@ -1,5 +1,14 @@
+{{ config(
+    materialized='incremental',
+    unique_key=['k_student_assessment']
+) }}
 with int_stu_assessments as (
     select * from {{ ref('int_ef3__student_assessments__identify_subject') }}
+
+    {% if is_incremental() %}
+    -- Only get new or updated records since the last run
+    and last_modified_timestamp > (select max(pull_timestamp) from {{ this }})
+    {% endif %}
 ),
 keyed as (
     select

--- a/models/staging/edfi_3/stage/stg_ef3__student_school_attendance_events.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_school_attendance_events.sql
@@ -1,5 +1,5 @@
 {{ config(
-    materialized='incremental',
+    materialized=var('edu:edfi_source:large_stg_materialization', 'table'),
     unique_key=['k_student', 'k_school', 'k_session', 'attendance_event_category', 'attendance_event_date'],
     post_hook=["{{edu_edfi_source.stg_post_hook_delete()}}"]
 ) }}

--- a/models/staging/edfi_3/stage/stg_ef3__student_school_attendance_events.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_school_attendance_events.sql
@@ -1,5 +1,15 @@
+{{ config(
+    materialized='incremental',
+    unique_key=['k_student', 'k_school', 'k_session', 'attendance_event_category', 'attendance_event_date'],
+    post_hook=["{{edu_edfi_source.stg_post_hook_delete()}}"]
+) }}
 with base_student_school_attend as (
     select * from {{ ref('base_ef3__student_school_attendance_events') }}
+
+    {% if is_incremental() %}
+    -- Only get newly added or deleted records since the last run
+    where last_modified_timestamp > (select max(last_modified_timestamp) from {{ this }})
+    {% endif %}
 ),
 keyed as (
     select 

--- a/models/staging/edfi_3/stage/stg_ef3__student_school_attendance_events.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_school_attendance_events.sql
@@ -31,4 +31,7 @@ deduped as (
     }}
 )
 select * from deduped
+{% if not is_incremental() %}
 where not is_deleted
+{% endif %}
+

--- a/models/staging/edfi_3/stage/stg_ef3__student_section_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_section_associations.sql
@@ -30,4 +30,7 @@ deduped as (
     }}
 )
 select * from deduped
+{% if not is_incremental() %}
 where not is_deleted
+{% endif %}
+

--- a/models/staging/edfi_3/stage/stg_ef3__student_section_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_section_associations.sql
@@ -1,5 +1,5 @@
 {{ config(
-    materialized='incremental',
+    materialized=var('edu:edfi_source:large_stg_materialization', 'table'),
     unique_key=['k_student', 'k_course_section', 'begin_date'],
     post_hook=["{{edu_edfi_source.stg_post_hook_delete()}}"]
 ) }}

--- a/models/staging/edfi_3/stage/stg_ef3__student_section_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_section_associations.sql
@@ -1,5 +1,15 @@
+{{ config(
+    materialized='incremental',
+    unique_key=['k_student', 'k_course_section', 'begin_date'],
+    post_hook=["{{edu_edfi_source.stg_post_hook_delete()}}"]
+) }}
 with base_student_section as (
     select * from {{ ref('base_ef3__student_section_associations') }}
+
+    {% if is_incremental() %}
+    -- Only get newly added or deleted records since the last run
+    where last_modified_timestamp > (select max(last_modified_timestamp) from {{ this }})
+    {% endif %}
 ),
 keyed as (
     select 

--- a/models/staging/edfi_3/stage/stg_ef3__student_section_attendance_events.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_section_attendance_events.sql
@@ -1,5 +1,5 @@
 {{ config(
-    materialized='incremental',
+    materialized=var('edu:edfi_source:large_stg_materialization', 'table'),
     unique_key=['k_student', 'k_course_section', 'attendance_event_category', 'attendance_event_date'],
     post_hook=["{{edu_edfi_source.stg_post_hook_delete()}}"]
 ) }}

--- a/models/staging/edfi_3/stage/stg_ef3__student_section_attendance_events.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_section_attendance_events.sql
@@ -1,5 +1,15 @@
+{{ config(
+    materialized='incremental',
+    unique_key=['k_student', 'k_course_section', 'attendance_event_category', 'attendance_event_date'],
+    post_hook=["{{edu_edfi_source.stg_post_hook_delete()}}"]
+) }}
 with base_student_section_attend as (
     select * from {{ ref('base_ef3__student_section_attendance_events') }}
+    
+    {% if is_incremental() %}
+    -- Only get newly added or deleted records since the last run
+    where last_modified_timestamp > (select max(last_modified_timestamp) from {{ this }})
+    {% endif %}
 ),
 keyed as (
     select 

--- a/models/staging/edfi_3/stage/stg_ef3__student_section_attendance_events.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_section_attendance_events.sql
@@ -30,4 +30,7 @@ deduped as (
     }}
 )
 select * from deduped
+{% if not is_incremental() %}
 where not is_deleted
+{% endif %}
+

--- a/models/staging/edfi_3/stage/stg_ef3__survey_question_responses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__survey_question_responses.sql
@@ -1,5 +1,5 @@
 {{ config(
-    materialized='incremental',
+    materialized=var('edu:edfi_source:large_stg_materialization', 'table'),
     unique_key=['k_survey_question', 'k_survey_response'],
     post_hook=["{{edu_edfi_source.stg_post_hook_delete()}}"]
 ) }}

--- a/models/staging/edfi_3/stage/stg_ef3__survey_question_responses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__survey_question_responses.sql
@@ -30,4 +30,7 @@ deduped as (
     }}
 )
 select * from deduped
+{% if not is_incremental() %}
 where not is_deleted
+{% endif %}
+

--- a/models/staging/edfi_3/stage/stg_ef3__survey_question_responses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__survey_question_responses.sql
@@ -1,5 +1,15 @@
+{{ config(
+    materialized='incremental',
+    unique_key=['k_survey_question', 'k_survey_response'],
+    post_hook=["{{edu_edfi_source.stg_post_hook_delete()}}"]
+) }}
 with base_survey_question_responses as (
     select * from {{ ref('base_ef3__survey_question_responses') }}
+
+    {% if is_incremental() %}
+    -- Only get newly added or deleted records since the last run
+    where last_modified_timestamp > (select max(last_modified_timestamp) from {{ this }})
+    {% endif %}
 ),
 keyed as (
     select 


### PR DESCRIPTION
##  Summary
This PR converts the largest `stg` models—based on volume of SC and TX runs—into **incremental models** to improve performance and efficiency. This change is **non-breaking and does nothing by default**, but you can configure the models to run as incremental by adding a dbt project var, or calling the var from CLI like:
```
dbt run --vars '{"edu:edfi_source:large_stg_materialization": "incremental"}'
```

To productionize, we should have edu_edfi_airflow add this^ code conditionally, and schedule in periodic full refreshes to avoid drift from unreliable raw schemas.

##  What's changed
1. **Incremental Logic Based on `last_modified_timestamp`**  
   - The models now only pull in records where `last_modified_timestamp > last run timestamp`.  
   - This significantly reduces the volume of processed data during each run.

2. **Handling Deletions**  
   - Records *newly deleted* since the last run are also pulled in because their `last_modified_timestamp` is updated.
   - To support this:
     - The existing `WHERE NOT is_deleted` clause is now **conditional**: it is applied *only* during full-refresh runs.
     - This ensures deleted records aren't prematurely excluded before being merged.

3. **Post-Hook Cleanup of Deleted Records**  
   - Since dbt incremental models use `MERGE` by default, deleted records are merged into the target table.
   - A **post-hook** is executed to clean up these now-merged deleted records from the target.

```mermaid
flowchart TD
    A[SOURCE: data from BASE, filtered to last_modified_timestamp > last_run_timestamp]
    A --> B[DEDUPE: including deletes so recent deletes are included in logic]
    B --> C[MERGE into Target Table: deletes are treated as UPDATES with is_deleted = true]
    C --> D[Post-hook: DELETE where is_deleted = TRUE]
```

## Migration
You will need to upgrade to `edu_rls` v0.1.1 if you have not already, to enable correct Row Access Policy generation on incremental models