### PR TITLE
Bugfix/extract descriptor skey

### DIFF
--- a/macros/extract_descriptor.sql
+++ b/macros/extract_descriptor.sql
@@ -1,7 +1,7 @@
 {# grab descriptor codes from namespaced descriptor values #}
-{% macro extract_descriptor(col) -%}
+{% macro extract_descriptor(col,descriptor_name=None) -%}
     
-    {%- set stripped_col = col.split(":")[-3] -%}
+    {%- set stripped_col = col.split(":")[-3] or descriptor_name -%}
     {%- set config = var('descriptors', {}).get(stripped_col) or None -%}
     {%- set replace_with = config['replace_with'] or None -%}
 

--- a/macros/gen_skey.sql
+++ b/macros/gen_skey.sql
@@ -405,13 +405,14 @@
         {%- set concatted_keys = concatted_keys + '::string::date' %}
       {% endif %}
 
-      {#- hack: wrap in lower to deal with case insensitive collations -#}
-      {% set concatted_keys = 'lower(' + concatted_keys + ')' %}
-
       {#- hack: if key contains Descriptor, parse value out -#}
       {% if 'Descriptor' in skey_var or 'descriptor' in skey_var %}
-        {%- set concatted_keys = edu_edfi_source.extract_descriptor(concatted_keys) %}
+        {%- set concatted_keys = edu_edfi_source.extract_descriptor(concatted_keys,descriptor_name=skey_var) %}
       {% endif %}
+
+      {#- hack: wrap in lower to deal with case insensitive collations -#}
+      {% set concatted_keys = 'lower(' + concatted_keys + ')' %}
+     
       {#- grow the output object with the new key -#}
       {% do output.append(concatted_keys) %}
     {% endfor %}


### PR DESCRIPTION
See full description and testing notes here https://edanalytics.atlassian.net/browse/STAD-94

@gnguyen87  recently helped dig into some failing tests in Texas and this led to us finding a bug here that impacts any surrogate key generated via gen_skey() that includes a descriptor field that has been replaced using the “replace descriptor” var functionality.
 

Basically, in these cases, the gen_skey() k_ value will NOT match the `dbt utils.surrogate_key()` version, because in the former, the descriptor replacement is not done, while in the latter it is (upstream in base).