### PR TITLE
Hotfix/k obj assess key consistency

### DIFF
--- a/models/staging/edfi_3/stage/stg_ef3__objective_assessments.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__objective_assessments.sql
@@ -38,10 +38,11 @@ keyed as (
             ['tenant_code',
             'api_year',
             'lower(academic_subject)',
+            'lower(obj_assess_academic_subject)',
             'lower(assessment_identifier)',
             'lower(namespace)',
-            'lower(obj_assess_academic_subject)',
-            'lower(objective_assessment_identification_code)']
+            'lower(objective_assessment_identification_code)'
+            ]
         ) }} as k_objective_assessment,
         {{ gen_skey('k_assessment', extras = ['academic_subject']) }},
         join_subject.*

--- a/models/staging/edfi_3/stage/stg_ef3__student_objective_assessments.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_objective_assessments.sql
@@ -17,6 +17,7 @@ flattened as (
         student_assessment_identifier,
         assessment_identifier,
         namespace,
+        assess_academic_subject,
         academic_subject,
         school_year,
         administration_date,
@@ -65,7 +66,7 @@ keyed as (
             'lower(objective_assessment_identification_code)',
             'lower(student_assessment_identifier)']
         ) }} as k_student_objective_assessment,
-        {{ gen_skey('k_objective_assessment', extras = ['academic_subject']) }},
+        {{ gen_skey('k_objective_assessment', extras = ['assess_academic_subject', 'academic_subject']) }},
         k_student_assessment,
         k_assessment,
         k_student,

--- a/models/staging/edfi_3/stage/stg_ef3__student_objective_assessments.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_objective_assessments.sql
@@ -17,7 +17,6 @@ flattened as (
         student_assessment_identifier,
         assessment_identifier,
         namespace,
-        assess_academic_subject,
         academic_subject,
         school_year,
         administration_date,
@@ -42,7 +41,8 @@ flattened as (
 joined as (
     select
       flattened.* exclude(academic_subject),
-      coalesce(stage_obj_assessments.academic_subject, flattened.academic_subject) as academic_subject
+      coalesce(stage_obj_assessments.academic_subject, flattened.academic_subject) as academic_subject,
+      stage_obj_assessments.assess_academic_subject
     from flattened
     join stage_obj_assessments
       on flattened.tenant_code = stage_obj_assessments.tenant_code
@@ -50,6 +50,12 @@ joined as (
       and flattened.assessment_identifier = stage_obj_assessments.assessment_identifier
       and flattened.namespace = stage_obj_assessments.namespace
       and flattened.objective_assessment_identification_code = stage_obj_assessments.objective_assessment_identification_code
+),
+{# TEMPORARY Rename academic_subject --> obj_assess_academic_subject & overall --> academic_subject to allow the gen_skey() call to behave consistent with stg_ef3__objective_assessments #}
+renamed1 as (
+    select 
+      * RENAME(academic_subject as obj_assess_academic_subject, assess_academic_subject as academic_subject)
+    from joined
 ),
 keyed as (
     select
@@ -66,7 +72,7 @@ keyed as (
             'lower(objective_assessment_identification_code)',
             'lower(student_assessment_identifier)']
         ) }} as k_student_objective_assessment,
-        {{ gen_skey('k_objective_assessment', extras = ['assess_academic_subject', 'academic_subject']) }},
+        {{ gen_skey('k_objective_assessment', extras = ['academic_subject', 'obj_assess_academic_subject']) }},
         k_student_assessment,
         k_assessment,
         k_student,
@@ -75,6 +81,7 @@ keyed as (
         assessment_identifier,
         namespace,
         academic_subject,
+        obj_assess_academic_subject,
         objective_assessment_identification_code,
         objective_assessment_reference,
         school_year,
@@ -90,14 +97,20 @@ keyed as (
         when_assessed_grade_level,
         v_performance_levels,
         v_score_results
-    from joined
+    from renamed1
+),
+{# Rename BACK obj_assess_academic_subject --> academic_subject for human-readability and to avoid breaking change to warehouse. academic_subject above represents 'OVERALL' assessment subject, so that the gen_skey() call works. #}
+renamed2 as (
+    select 
+      * RENAME(academic_subject as assess_academic_subject, obj_assess_academic_subject as academic_subject)
+    from keyed
 ),
 -- todo: we already dedupe in student assessments so this is actually only necessary if we think there
     -- could be dupes in the objective assessments list
 deduped as (
     {{
         dbt_utils.deduplicate(
-            relation='keyed',
+            relation='renamed2',
             partition_by='k_student_objective_assessment',
             order_by='last_modified_timestamp desc, pull_timestamp desc'
         )


### PR DESCRIPTION
in 047, while resolving key issues for `k_assessment`, a bug was introduced to `k_objective_assessment`, leading to inconsistency between `stg_ef3__objective_assessments` and `stg_ef3__student_objectie_assessments`.

This has been re-tested in SC, can see difference here:
```
-- PROD: NO ROWS RETURNED
select count(*)
from analytics.prod_wh.fct_student_objective_assessment 
inner join analytics.prod_wh.dim_objective_assessment 
    on fct_student_objective_assessment.k_objective_assessment = 
        dim_objective_assessment.k_objective_assessment;
-- DEV: ALL ROWS RETURNED
select count(*)
from dev_analytics.dev_rl_wh.fct_student_objective_assessment 
inner join dev_analytics.dev_rl_wh.dim_objective_assessment 
    on fct_student_objective_assessment.k_objective_assessment = 
        dim_objective_assessment.k_objective_assessment;
```

Three changes were needed:
1. Add `obj_assess_academic_subject` to `extras` here: https://github.com/edanalytics/edu_edfi_source/blob/bcdf3d4bd5ef1181dfbb9fb2f5b067cf37e8ea71/models/staging/edfi_3/stage/stg_ef3__student_objective_assessments.sql#L75
2. Add `renamed` CTEs to before & after that^, to make sure the right names are used for skey & final table, respectively.
3. Rearrange keys in `stg_ef3__objective_assessments` key generation [here](https://github.com/edanalytics/edu_edfi_source/pull/135/files#diff-10ec8cb19bab1fb26896324474b6d881d45f00f26a50026519960495ec90f7fc), because they must match alphabetically with what's produced by `gen_skey()`, which will include the Reference name, e.g. `objective_assessment_reference:namespace`, which needs to come AFTER `obj_assess_academic_subject`, not before. 


NOTE, I tried some ways of doing without needing the double-rename, but it's too confusing and would require updates to the `gen_skey()` macro. Maybe we should think about a redesign of that macro to handle complicated cases like these in a more readable way, but that's not for this hotfix branch
