### PR TITLE
fix staff sec key for 5.0 and later

### DIFF
--- a/models/staging/edfi_3/stage/stg_ef3__staff_section_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__staff_section_associations.sql
@@ -5,7 +5,13 @@ keyed as (
     select 
         {{ gen_skey('k_staff') }},
         {{ gen_skey('k_course_section') }},
-        base_staff_section_assoc.*
+        base_staff_section_assoc.*,
+        -- prior to 5.0, begin date was not part of the key, so should not be used in deduplication
+        -- after 5.0, begin date should be used in deduplication
+        case
+            when base_staff_section_assoc.data_model_version < '5' then null
+            else begin_date
+        end as begin_date_key
         {{ extract_extension(model_name=this.name, flatten=True) }}
     from base_staff_section_assoc
 ),
@@ -13,7 +19,7 @@ deduped as (
     {{
         dbt_utils.deduplicate(
             relation='keyed',
-            partition_by='k_staff, k_course_section',
+            partition_by='k_staff, k_course_section, begin_date_key',
             order_by='last_modified_timestamp desc, pull_timestamp desc'
         )
     }}


### PR DESCRIPTION
5.0 added begin_date to the key of staff_section_association. This PR alters the key such that in data from standards prior to 5.0 we do not affect the grain, and in 5.0 and later, we inject begin_date.