### PR TITLE
fix/epdm_models: Remove uneccessary keys in stg models

### DIFF
--- a/models/staging/tpdm/stage/stg_tpdm__candidate_educator_preparation_program_associations.sql
+++ b/models/staging/tpdm/stage/stg_tpdm__candidate_educator_preparation_program_associations.sql
@@ -3,17 +3,6 @@ with candidate_educator_preparation_program_associations as (
 ),
 keyed as (
     select
-        {{ dbt_utils.generate_surrogate_key(
-            [
-                'tenant_code',
-                'api_year',
-                'begin_date',
-                'lower(candidate_id)',
-                'ed_org_id',
-                'lower(program_name)',
-                'lower(program_type)'
-            ]
-        ) }} as k_candidate_educator_preparation_program_association,
         {{ gen_skey('k_candidate') }},
         {{ gen_skey('k_educator_prep_program') }},
         candidate_educator_preparation_program_associations.*
@@ -24,7 +13,7 @@ deduped as (
     {{
         dbt_utils.deduplicate(
             relation='keyed',
-            partition_by='k_candidate_educator_preparation_program_association',
+            partition_by='k_candidate, k_educator_prep_program',
             order_by='last_modified_timestamp desc, pull_timestamp desc'
         )
     }}

--- a/models/staging/tpdm/stage/stg_tpdm__survey_response_person_target_associations.sql
+++ b/models/staging/tpdm/stage/stg_tpdm__survey_response_person_target_associations.sql
@@ -3,15 +3,6 @@ with survey_response_person_target_associations as (
 ),
 keyed as (
     select 
-        {{ dbt_utils.generate_surrogate_key(
-            ['tenant_code',
-            'api_year',
-            'lower(namespace)',
-            'lower(person_id)',
-            'lower(source_system)',
-            'lower(survey_id)',
-            'lower(survey_response_id)']
-        ) }} as k_survey_response_person_target_association,
         {{ gen_skey('k_survey_response') }},
         {{ gen_skey('k_person') }},
         survey_response_person_target_associations.*
@@ -22,7 +13,7 @@ deduped as (
     {{
         dbt_utils.deduplicate(
             relation='keyed',
-            partition_by='k_survey_response_person_target_association',
+            partition_by='k_survey_response, k_person',
             order_by='last_modified_timestamp desc, pull_timestamp desc')
     }}
 )


### PR DESCRIPTION
## Description
The staging models for `candidate_educator_preparation_program_associations` and `survey_response_person_target_associations` both generate a surrogate key that is never referenced in other models. There does not seem to be any other potential use for these keys in the future, so they might be unecessary. This PR removes them.

## Modified files
* `models/staging/tpdm/stage/stg_tpdm__candidate_educator_preparation_program_associations.sql`
* `models/staging/tpdm/stage/stg_tpdm__survey_response_person_target_associations.sql`