### PR TITLE
Fix/add k_assessment to stg_ef3__student_assessments_score_results and stg_ef3__student_assessments_performance_levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add `stg_ef3__students__other_names`
 
 ## Under the hood
+- Add `k_assessment` to `stg_ef3__student_assessments__score_results` and `stg_ef3__student_assessments__performance_levels` for use downstream
 ## Fixes
 
 # edu_edfi_source v0.5.0

--- a/models/staging/edfi_3/stage/stg_ef3__student_assessments__performance_levels.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_assessments__performance_levels.sql
@@ -6,6 +6,7 @@ flattened as (
         tenant_code,
         api_year,
         k_student_assessment,
+        k_assessment,
         -- used for xwalk in wh
         assessment_identifier,
         namespace,

--- a/models/staging/edfi_3/stage/stg_ef3__student_assessments__score_results.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_assessments__score_results.sql
@@ -6,6 +6,7 @@ flattened as (
         tenant_code,
         api_year,
         k_student_assessment,
+        k_assessment,
         -- used for xwalk in wh
         assessment_identifier,
         namespace,


### PR DESCRIPTION
Linked to [PR 185 in edu_wh](https://github.com/edanalytics/edu_wh/pull/185):

- add in k_assessment to stg_ef3__student_assessments__score_results
- add in k_assessment to stg_ef3__student_assessments__performance_levels

This is necessary to join in assessment_family from dim_assessment in bld_ef3__student_assessments_long_results.