### PR TITLE
Fix/dbt test updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+- Updated `gen_skey.sql` macro. Changed the order of `k_survey_section` column list. Changed survey_section_title from snake case to camel case. 
+- Corrected `stg_ef3__survey_section_responses.sql` model `k_survey_section_response` variable. previously missing `survey_response_id` variable. 
 ## New features
 ## Under the hood
 ## Fixes

--- a/macros/gen_skey.sql
+++ b/macros/gen_skey.sql
@@ -229,7 +229,7 @@
 
         'k_survey_section': {
             'reference_name': 'survey_section_reference',
-            'col_list': ['namespace', 'surveyIdentifier', 'survey_section_title'],
+            'col_list': ['surveyIdentifier', 'namespace', 'surveySectionTitle'],
             'annualize': True
         },
 

--- a/models/staging/edfi_3/stage/stg_ef3__survey_section_responses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__survey_section_responses.sql
@@ -8,7 +8,9 @@ keyed as (
             'api_year',
             'lower(survey_id)',
             'lower(namespace)',
-            'lower(survey_section_title)']
+            'lower(survey_section_title)', 
+            'lower(survey_response_id)'
+            ]
         ) }} as k_survey_section_response,
         {{ gen_skey('k_survey_response') }},
         {{ gen_skey('k_survey_section') }},


### PR DESCRIPTION
## fix/dbt_test_updates

## Description & motivation:
The `relationships_stg_ef3__survey_section_responses_k_survey_section__k_survey_section__ref_stg_ef3__survey_sections` referential integrity test was failing due to a mismatch in columns. To resolve this, the `k_survey_section` entry in `macros/gen_skey.sql` was  changed to match the column order in the parent model’s `k_survey_section`.

## PR Merge Priority:
- [x] Low </br>
- [ ] Medium </br>
- [ ] High </br>

## Changes to existing docs:
- `stg_ef3__survey_section_responses.sql` : corrected creation of `k_survey_section_response` variable. Was missing survey_response_id (this was caught by @jalvord1).</br>
- `macros/gen_skey.sql`: Changed order of k_assessment column order. Changed `surveySectionTitle` from snake case to camel case.</br>

## Tests and QC done:
- Ran locally to ensure test passed.</br>