### PR TITLE
TDOE enhancements/fixes to Program Association artifacts

### DIFF
--- a/models/staging/edfi_3/base/base_ef3__student_migrant_education_program_associations.sql
+++ b/models/staging/edfi_3/base/base_ef3__student_migrant_education_program_associations.sql
@@ -22,6 +22,7 @@ renamed as (
         v:beginDate::date                                                                           as program_enroll_begin_date,
         v:endDate::date                                                                             as program_enroll_end_date, 
         v:programReference:programName::string                                                      as program_name, 
+        v:programReference:educationOrganizationId::int                                             as program_ed_org_id,
 
         v:priorityForServices::boolean                                                              as priority_for_service, 
 

--- a/models/staging/edfi_3/stage/_edfi_3__stage.yml
+++ b/models/staging/edfi_3/stage/_edfi_3__stage.yml
@@ -548,6 +548,11 @@ models:
       tags: ['cte']
       enabled: "{{ var('src:program:cte:enabled', True) }}"
 
+  - name: stg_ef3__stu_cte__program_participation_statuses
+    config:
+      tags: ['cte']
+      enabled: "{{ var('src:program:cte:enabled', True) }}"
+
   - name: stg_ef3__stu_ed_org__addresses
     config:
       tags: ['core']
@@ -589,6 +594,11 @@ models:
       tags: ['homeless']
       enabled: "{{ var('src:program:homeless:enabled', True) }}"
 
+  - name: stg_ef3__stu_homeless__program_participation_statuses
+    config:
+      tags: ['homeless']
+      enabled: "{{ var('src:program:homeless:enabled', True) }}"
+
   - name: stg_ef3__stu_lang_instr__proficiency_assessments
     config:
       tags: ['language_instruction']
@@ -599,12 +609,35 @@ models:
       tags: ['language_instruction']
       enabled: "{{ var('src:program:language_instruction:enabled', True) }}"
 
+  - name: stg_ef3__stu_lang_instr__program_participation_statuses
+    config:
+      tags: ['language_instruction']
+      enabled: "{{ var('src:program:language_instruction:enabled', True) }}"
+
   - name: stg_ef3__stu_migrant_edu__program_services
     config: 
       tags: ['migrant_education']
       enabled: "{{ var('src:program:migrant_education:enabled', True) }}"
 
+  - name: stg_ef3__stu_migrant_edu__program_participation_statuses
+    config: 
+      tags: ['migrant_education']
+      enabled: "{{ var('src:program:migrant_education:enabled', True) }}"
+
+  - name: stg_ef3__stu_program__program_services
+    config: 
+      tags: ['core']
+
+  - name: stg_ef3__stu_program__program_participation_statuses
+    config: 
+      tags: ['core']
+
   - name: stg_ef3__stu_school_food_service__program_services
+    config: 
+      tags: ['food_service']
+      enabled: "{{ var('src:program:food_service:enabled', True) }}"
+
+  - name: stg_ef3__stu_school_food_service__program_participation_statuses
     config: 
       tags: ['food_service']
       enabled: "{{ var('src:program:food_service:enabled', True) }}"
@@ -619,7 +652,17 @@ models:
       tags: ['special_ed']
       enabled: "{{ var('src:program:special_ed:enabled', True) }}"
 
+  - name: stg_ef3__stu_spec_ed__program_participation_statuses
+    config:
+      tags: ['special_ed']
+      enabled: "{{ var('src:program:special_ed:enabled', True) }}"
+
   - name: stg_ef3__stu_title_i_part_a__program_services
+    config:
+      tags: ['title_i']
+      enabled: "{{ var('src:program:title_i:enabled', True) }}"
+
+  - name: stg_ef3__stu_title_i_part_a__program_participation_statuses
     config:
       tags: ['title_i']
       enabled: "{{ var('src:program:title_i:enabled', True) }}"

--- a/models/staging/edfi_3/stage/stg_ef3__stu_cte__program_participation_statuses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_cte__program_participation_statuses.sql
@@ -15,17 +15,16 @@ flattened as (
 
         program_enroll_begin_date,
         program_enroll_end_date,
-        {{ extract_descriptor('value:cteProgramServiceDescriptor::string') }} as program_service,
-        value:primaryIndicator::boolean         as primary_indicator, 
-        value:serviceBeginDate::date            as service_begin_date,
-        value:serviceEndDate::date              as service_end_date,
-        value:cipCode::string                   as cip_code,
+        {{ extract_descriptor('value:participationStatusDescriptor::string') }} as participation_status,
+        value:statusBeginDate::date     as status_begin_date,
+        value:designatedBy              as designated_by,
+        value:statusEndDate::date       as status_end_date,
 
         -- edfi extensions
         value:_ext as v_ext
 
     from stage_stu_programs
-        {{ json_flatten('v_cte_program_services') }}
+        {{ json_flatten('v_program_participation_statuses') }}
 )
 
 select * from flattened

--- a/models/staging/edfi_3/stage/stg_ef3__stu_cte__program_participation_statuses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_cte__program_participation_statuses.sql
@@ -4,6 +4,7 @@ with stage_stu_programs as (
 
 flattened as (
     select 
+        k_student_program,
         tenant_code,
         api_year,
         k_student,

--- a/models/staging/edfi_3/stage/stg_ef3__stu_cte__program_services.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_cte__program_services.sql
@@ -4,6 +4,7 @@ with stage_stu_programs as (
 
 flattened as (
     select 
+        k_student_program,
         tenant_code,
         api_year,
         k_student,

--- a/models/staging/edfi_3/stage/stg_ef3__stu_ed_org__disabilities.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_ed_org__disabilities.sql
@@ -5,6 +5,7 @@ flattened as (
     select
         tenant_code,
         api_year,
+        school_year,
         k_student,
         k_student_xyear,
         ed_org_id,
@@ -14,12 +15,8 @@ flattened as (
         {{ extract_descriptor('disab.value:disabilityDeterminationSourceTypeDescriptor::string') }} as disability_source_type,
         disab.value:disabilityDiagnosis::string as disability_diagnosis,
         disab.value:orderOfDisability::int as order_of_disability,
-        -- todo: perhaps these would better serve as wide booleans
-        -- in which case we would not want to double-flatten, but leave nested
-        -- for a downstream step
-        {{ extract_descriptor('desig.value:disabilityDesignationDescriptor::string') }} as disability_designation
+        disab.value:designations as v_designations
     from stg_stu_ed_org
         {{ json_flatten('v_disabilities', 'disab') }}
-        {{ json_flatten('disab.value:designations', 'desig') }}
 )
 select * from flattened

--- a/models/staging/edfi_3/stage/stg_ef3__stu_homeless__program_participation_statuses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_homeless__program_participation_statuses.sql
@@ -12,19 +12,19 @@ flattened as (
         k_lea,
         k_school,
         ed_org_id,
+
         program_enroll_begin_date,
         program_enroll_end_date,
-        {{ extract_descriptor('value:homelessProgramServiceDescriptor::string') }} as program_service,
-        value:primaryIndicator::boolean as primary_indicator,
-        value:providers                 as v_providers,
-        value:serviceBeginDate::date    as service_begin_date,
-        value:serviceEndDate::date      as service_end_date,
+        {{ extract_descriptor('value:participationStatusDescriptor::string') }} as participation_status,
+        value:statusBeginDate::date     as status_begin_date,
+        value:designatedBy              as designated_by,
+        value:statusEndDate::date       as status_end_date,
 
         -- edfi extensions
         value:_ext as v_ext
 
     from stage_stu_programs
-        {{ json_flatten('v_homeless_program_services') }}
+        {{ json_flatten('v_program_participation_statuses') }}
 )
 
 select * from flattened

--- a/models/staging/edfi_3/stage/stg_ef3__stu_homeless__program_participation_statuses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_homeless__program_participation_statuses.sql
@@ -4,6 +4,7 @@ with stage_stu_programs as (
 
 flattened as (
     select
+        k_student_program,
         tenant_code,
         api_year,
         k_student,

--- a/models/staging/edfi_3/stage/stg_ef3__stu_homeless__program_services.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_homeless__program_services.sql
@@ -4,6 +4,7 @@ with stage_stu_programs as (
 
 flattened as (
     select
+        k_student_program,
         tenant_code,
         api_year,
         k_student,

--- a/models/staging/edfi_3/stage/stg_ef3__stu_lang_instr__proficiency_assessments.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_lang_instr__proficiency_assessments.sql
@@ -4,6 +4,7 @@ with stage_stu_programs as (
 
 flattened as (
     select
+        k_student_program,
         tenant_code,
         api_year,
         k_student,

--- a/models/staging/edfi_3/stage/stg_ef3__stu_lang_instr__program_participation_statuses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_lang_instr__program_participation_statuses.sql
@@ -4,6 +4,7 @@ with stage_stu_programs as (
 
 flattened as (
     select
+        k_student_program,
         tenant_code,
         api_year,
         k_student,

--- a/models/staging/edfi_3/stage/stg_ef3__stu_lang_instr__program_participation_statuses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_lang_instr__program_participation_statuses.sql
@@ -15,17 +15,16 @@ flattened as (
 
         program_enroll_begin_date,
         program_enroll_end_date,
-        {{ extract_descriptor('value:languageInstructionProgramServiceDescriptor::string') }} as program_service,
-        value:primaryIndicator::boolean as primary_indicator,
-        value:providers                 as v_providers,
-        value:serviceBeginDate::date    as service_begin_date,
-        value:serviceEndDate::date      as service_end_date,
+        {{ extract_descriptor('value:participationStatusDescriptor::string') }} as participation_status,
+        value:statusBeginDate::date     as status_begin_date,
+        value:designatedBy              as designated_by,
+        value:statusEndDate::date       as status_end_date,
 
         -- edfi extensions
         value:_ext as v_ext
 
     from stage_stu_programs
-        {{ json_flatten('v_language_instruction_program_services') }}
+        {{ json_flatten('v_program_participation_statuses') }}
 )
 
 select * from flattened

--- a/models/staging/edfi_3/stage/stg_ef3__stu_lang_instr__program_services.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_lang_instr__program_services.sql
@@ -4,6 +4,7 @@ with stage_stu_programs as (
 
 flattened as (
     select
+        k_student_program,
         tenant_code,
         api_year,
         k_student,

--- a/models/staging/edfi_3/stage/stg_ef3__stu_migrant_edu__program_participation_statuses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_migrant_edu__program_participation_statuses.sql
@@ -4,6 +4,7 @@ with stage_stu_programs as (
 
 flattened as (
     select
+        k_student_program,
         tenant_code,
         api_year,
         k_student,

--- a/models/staging/edfi_3/stage/stg_ef3__stu_migrant_edu__program_participation_statuses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_migrant_edu__program_participation_statuses.sql
@@ -15,16 +15,16 @@ flattened as (
 
         program_enroll_begin_date,
         program_enroll_end_date,
-        {{ extract_descriptor('value:migrantEducationProgramServiceDescriptor::string') }} as program_service,
-        value:primaryIndicator::boolean as primary_indicator,
-        value:serviceBeginDate::date    as service_begin_date,
-        value:serviceEndDate::date      as service_end_date,
+        {{ extract_descriptor('value:participationStatusDescriptor::string') }} as participation_status,
+        value:statusBeginDate::date     as status_begin_date,
+        value:designatedBy              as designated_by,
+        value:statusEndDate::date       as status_end_date,
 
         -- edfi extensions
         value:_ext as v_ext
 
     from stage_stu_programs
-        {{ json_flatten('v_migrant_education_program_services') }}
+        {{ json_flatten('v_program_participation_statuses') }}
 )
 
 select * from flattened

--- a/models/staging/edfi_3/stage/stg_ef3__stu_migrant_edu__program_services.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_migrant_edu__program_services.sql
@@ -4,6 +4,7 @@ with stage_stu_programs as (
 
 flattened as (
     select
+        k_student_program,
         tenant_code,
         api_year,
         k_student,

--- a/models/staging/edfi_3/stage/stg_ef3__stu_program__program_participation_statuses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_program__program_participation_statuses.sql
@@ -4,6 +4,7 @@ with stage_stu_programs as (
 
 flattened as (
     select
+        k_student_program,
         tenant_code,
         api_year,
         school_year,

--- a/models/staging/edfi_3/stage/stg_ef3__stu_program__program_participation_statuses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_program__program_participation_statuses.sql
@@ -1,0 +1,31 @@
+with stage_stu_programs as (
+    select * from {{ ref('stg_ef3__student_program_associations') }}
+),
+
+flattened as (
+    select
+        tenant_code,
+        api_year,
+        school_year,
+        k_student,
+        k_student_xyear,
+        k_program,
+        k_lea,
+        k_school,
+        ed_org_id,
+
+        program_enroll_begin_date,
+        program_enroll_end_date,
+        {{ extract_descriptor('value:participationStatusDescriptor::string') }} as participation_status,
+        value:statusBeginDate::date     as status_begin_date,
+        value:designatedBy              as designated_by,
+        value:statusEndDate::date       as status_end_date,
+
+        -- edfi extensions
+        value:_ext as v_ext
+
+    from stage_stu_programs
+        {{ json_flatten('v_program_participation_statuses') }}
+)
+
+select * from flattened

--- a/models/staging/edfi_3/stage/stg_ef3__stu_program__program_services.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_program__program_services.sql
@@ -4,6 +4,7 @@ with stage_stu_programs as (
 
 flattened as (
     select
+        k_student_program,
         tenant_code,
         api_year,
         school_year,

--- a/models/staging/edfi_3/stage/stg_ef3__stu_program__program_services.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_program__program_services.sql
@@ -1,22 +1,23 @@
 with stage_stu_programs as (
-    select * from {{ ref('stg_ef3__student_homeless_program_associations') }}
+    select * from {{ ref('stg_ef3__student_program_associations') }}
 ),
 
 flattened as (
     select
         tenant_code,
         api_year,
+        school_year,
         k_student,
         k_student_xyear,
         k_program,
         k_lea,
         k_school,
         ed_org_id,
+
         program_enroll_begin_date,
         program_enroll_end_date,
-        {{ extract_descriptor('value:homelessProgramServiceDescriptor::string') }} as program_service,
+        {{ extract_descriptor('value:programServiceDescriptor::string') }} as program_service,
         value:primaryIndicator::boolean as primary_indicator,
-        value:providers                 as v_providers,
         value:serviceBeginDate::date    as service_begin_date,
         value:serviceEndDate::date      as service_end_date,
 
@@ -24,7 +25,7 @@ flattened as (
         value:_ext as v_ext
 
     from stage_stu_programs
-        {{ json_flatten('v_homeless_program_services') }}
+        {{ json_flatten('v_services') }}
 )
 
 select * from flattened

--- a/models/staging/edfi_3/stage/stg_ef3__stu_school_food_service__program_participation_statuses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_school_food_service__program_participation_statuses.sql
@@ -11,20 +11,20 @@ flattened as (
         k_program,
         k_lea,
         k_school,
-
         ed_org_id,
+
         program_enroll_begin_date,
         program_enroll_end_date,
-        {{ extract_descriptor('value:schoolFoodServiceProgramServiceDescriptor::string') }} as program_service,
-        value:primaryIndicator::boolean as primary_indicator,
-        value:serviceBeginDate::date    as service_begin_date,
-        value:serviceEndDate::date      as service_end_date,
+        {{ extract_descriptor('value:participationStatusDescriptor::string') }} as participation_status,
+        value:statusBeginDate::date     as status_begin_date,
+        value:designatedBy              as designated_by,
+        value:statusEndDate::date       as status_end_date,
 
         -- edfi extensions
         value:_ext as v_ext
 
     from stage_stu_programs
-        {{ json_flatten('v_school_food_service_program_services') }}
+        {{ json_flatten('v_program_participation_statuses') }}
 )
 
 select * from flattened

--- a/models/staging/edfi_3/stage/stg_ef3__stu_school_food_service__program_participation_statuses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_school_food_service__program_participation_statuses.sql
@@ -4,6 +4,7 @@ with stage_stu_programs as (
 
 flattened as (
     select
+        k_student_program,
         tenant_code,
         api_year,
         k_student,

--- a/models/staging/edfi_3/stage/stg_ef3__stu_school_food_service__program_services.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_school_food_service__program_services.sql
@@ -4,6 +4,7 @@ with stage_stu_programs as (
 
 flattened as (
     select
+        k_student_program,
         tenant_code,
         api_year,
         k_student,

--- a/models/staging/edfi_3/stage/stg_ef3__stu_spec_ed__disabilities.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_spec_ed__disabilities.sql
@@ -4,14 +4,16 @@ with stg_stu_spec_ed_org as (
 flattened as (
     select
         tenant_code,
+        api_year,
+        school_year,
         k_student,
         k_student_xyear,
-        k_program,
+        ed_org_id,
         k_lea,
         k_school,
+        k_program,
         program_enroll_begin_date,
         program_enroll_end_date,
-        school_year,
         {{ extract_descriptor('disab.value:disabilityDescriptor::string') }} as disability_type,
         {{ extract_descriptor('disab.value:disabilityDeterminationSourceTypeDescriptor::string') }} as disability_source_type,
         disab.value:disabilityDiagnosis::string as disability_diagnosis,

--- a/models/staging/edfi_3/stage/stg_ef3__stu_spec_ed__program_participation_statuses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_spec_ed__program_participation_statuses.sql
@@ -15,17 +15,16 @@ flattened as (
 
         program_enroll_begin_date,
         program_enroll_end_date,
-        {{ extract_descriptor('value:specialEducationProgramServiceDescriptor::string') }} as program_service,
-        value:primaryIndicator::boolean as primary_indicator,
-        value:providers                 as v_providers,
-        value:serviceBeginDate::date    as service_begin_date,
-        value:serviceEndDate::date      as service_end_date,
+        {{ extract_descriptor('value:participationStatusDescriptor::string') }} as participation_status,
+        value:statusBeginDate::date     as status_begin_date,
+        value:designatedBy              as designated_by,
+        value:statusEndDate::date       as status_end_date,
 
         -- edfi extensions
         value:_ext as v_ext
 
     from stage_stu_programs
-        {{ json_flatten('v_special_education_program_services') }}
+        {{ json_flatten('v_program_participation_statuses') }}
 ),
 
 -- There is a v_ext nested within v_special_education_program_services. Those extensions must be extracted here, not in prev CTE, 

--- a/models/staging/edfi_3/stage/stg_ef3__stu_spec_ed__program_participation_statuses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_spec_ed__program_participation_statuses.sql
@@ -4,6 +4,7 @@ with stage_stu_programs as (
 
 flattened as (
     select
+        k_student_program,
         tenant_code,
         api_year,
         k_student,

--- a/models/staging/edfi_3/stage/stg_ef3__stu_spec_ed__program_services.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_spec_ed__program_services.sql
@@ -4,6 +4,7 @@ with stage_stu_programs as (
 
 flattened as (
     select
+        k_student_program,
         tenant_code,
         api_year,
         k_student,

--- a/models/staging/edfi_3/stage/stg_ef3__stu_title_i_part_a__program_participation_statuses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_title_i_part_a__program_participation_statuses.sql
@@ -12,18 +12,19 @@ flattened as (
         k_lea,
         k_school,
         ed_org_id,
+
         program_enroll_begin_date,
         program_enroll_end_date,
-        {{ extract_descriptor('value:titleIPartAProgramServiceDescriptor::string') }} as program_service,
-        value:primaryIndicator::boolean as primary_indicator,
-        value:providers                 as v_providers,
-        value:serviceBeginDate::date    as service_begin_date,
-        value:serviceEndDate::date      as service_end_date,
+        {{ extract_descriptor('value:participationStatusDescriptor::string') }} as participation_status,
+        value:statusBeginDate::date     as status_begin_date,
+        value:designatedBy              as designated_by,
+        value:statusEndDate::date       as status_end_date,
 
         -- edfi extensions
         value:_ext as v_ext
 
     from stage_stu_programs
-        {{ json_flatten('v_title_i_part_a_program_services') }}
+        {{ json_flatten('v_program_participation_statuses') }}
 )
+
 select * from flattened

--- a/models/staging/edfi_3/stage/stg_ef3__stu_title_i_part_a__program_participation_statuses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_title_i_part_a__program_participation_statuses.sql
@@ -4,6 +4,7 @@ with stage_stu_programs as (
 
 flattened as (
     select
+        k_student_program,
         tenant_code,
         api_year,
         k_student,

--- a/models/staging/edfi_3/stage/stg_ef3__stu_title_i_part_a__program_services.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_title_i_part_a__program_services.sql
@@ -4,6 +4,7 @@ with stage_stu_programs as (
 
 flattened as (
     select
+        k_student_program,
         tenant_code,
         api_year,
         k_student,

--- a/models/staging/edfi_3/stage/stg_ef3__stu_title_i_part_a__services.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_title_i_part_a__services.sql
@@ -11,6 +11,7 @@ flattened as (
         k_program,
         k_lea,
         k_school,
+        ed_org_id,
 
         {{ extract_descriptor('value:serviceDescriptor::string') }} as service,
         value:primaryIndicator::boolean as primary_indicator,

--- a/models/staging/edfi_3/stage/stg_ef3__stu_title_i_part_a__services.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_title_i_part_a__services.sql
@@ -4,6 +4,7 @@ with stage_stu_programs as (
 
 flattened as (
     select
+        k_student_program,
         tenant_code,
         api_year,
         k_student,

--- a/models/staging/edfi_3/stage/stg_ef3__student_cte_program_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_cte_program_associations.sql
@@ -18,7 +18,7 @@ keyed as (
 deduped as (
     {{ dbt_utils.deduplicate(
         relation='keyed',
-        partition_by='k_student, k_program, program_enroll_begin_date, school_year',
+        partition_by='k_student, k_program, program_enroll_begin_date, school_year, ed_org_id',
         order_by='last_modified_timestamp desc, pull_timestamp desc'
     ) }}
 )

--- a/models/staging/edfi_3/stage/stg_ef3__student_cte_program_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_cte_program_associations.sql
@@ -4,6 +4,18 @@ with base_stu_programs as (
 
 keyed as (
     select 
+        {{ dbt_utils.generate_surrogate_key(
+            [
+                'tenant_code',
+                'api_year',
+                'lower(student_unique_id)',
+                'ed_org_id',
+                'program_ed_org_id',
+                'lower(program_name)',
+                'lower(program_type)',
+                'program_enroll_begin_date'
+            ]
+        ) }} as k_student_program,
         {{ gen_skey('k_student') }},
         {{ gen_skey('k_student_xyear') }},
         {{ gen_skey('k_program') }},
@@ -18,7 +30,7 @@ keyed as (
 deduped as (
     {{ dbt_utils.deduplicate(
         relation='keyed',
-        partition_by='k_student, k_program, program_enroll_begin_date, school_year, ed_org_id',
+        partition_by='k_student_program',
         order_by='last_modified_timestamp desc, pull_timestamp desc'
     ) }}
 )

--- a/models/staging/edfi_3/stage/stg_ef3__student_homeless_program_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_homeless_program_associations.sql
@@ -18,7 +18,7 @@ keyed as (
 deduped as (
     {{ dbt_utils.deduplicate(
         relation='keyed',
-        partition_by='k_student, k_program, program_enroll_begin_date, school_year',
+        partition_by='k_student, k_program, program_enroll_begin_date, school_year, ed_org_id',
         order_by='last_modified_timestamp desc, pull_timestamp desc'
     ) }}
 )

--- a/models/staging/edfi_3/stage/stg_ef3__student_homeless_program_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_homeless_program_associations.sql
@@ -4,6 +4,18 @@ with base_stu_programs as (
 
 keyed as (
     select 
+        {{ dbt_utils.generate_surrogate_key(
+            [
+                'tenant_code',
+                'api_year',
+                'lower(student_unique_id)',
+                'ed_org_id',
+                'program_ed_org_id',
+                'lower(program_name)',
+                'lower(program_type)',
+                'program_enroll_begin_date'
+            ]
+        ) }} as k_student_program,
         {{ gen_skey('k_student') }},
         {{ gen_skey('k_student_xyear') }},
         {{ gen_skey('k_program') }},
@@ -18,7 +30,7 @@ keyed as (
 deduped as (
     {{ dbt_utils.deduplicate(
         relation='keyed',
-        partition_by='k_student, k_program, program_enroll_begin_date, school_year, ed_org_id',
+        partition_by='k_student_program',
         order_by='last_modified_timestamp desc, pull_timestamp desc'
     ) }}
 )

--- a/models/staging/edfi_3/stage/stg_ef3__student_language_instruction_program_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_language_instruction_program_associations.sql
@@ -18,7 +18,7 @@ keyed as (
 deduped as (
     {{ dbt_utils.deduplicate(
         relation='keyed',
-        partition_by='k_student, k_program, program_enroll_begin_date, school_year',
+        partition_by='k_student, k_program, program_enroll_begin_date, school_year, ed_org_id',
         order_by='last_modified_timestamp desc, pull_timestamp desc'
     ) }}
 )

--- a/models/staging/edfi_3/stage/stg_ef3__student_language_instruction_program_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_language_instruction_program_associations.sql
@@ -4,6 +4,18 @@ with base_stu_programs as (
 
 keyed as (
     select 
+        {{ dbt_utils.generate_surrogate_key(
+            [
+                'tenant_code',
+                'api_year',
+                'lower(student_unique_id)',
+                'ed_org_id',
+                'program_ed_org_id',
+                'lower(program_name)',
+                'lower(program_type)',
+                'program_enroll_begin_date'
+            ]
+        ) }} as k_student_program,
         {{ gen_skey('k_student') }},
         {{ gen_skey('k_student_xyear') }},
         {{ gen_skey('k_program') }},
@@ -18,7 +30,7 @@ keyed as (
 deduped as (
     {{ dbt_utils.deduplicate(
         relation='keyed',
-        partition_by='k_student, k_program, program_enroll_begin_date, school_year, ed_org_id',
+        partition_by='k_student_program',
         order_by='last_modified_timestamp desc, pull_timestamp desc'
     ) }}
 )

--- a/models/staging/edfi_3/stage/stg_ef3__student_migrant_education_program_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_migrant_education_program_associations.sql
@@ -18,7 +18,7 @@ keyed as (
 deduped as (
     {{ dbt_utils.deduplicate(
         relation='keyed',
-        partition_by='k_student, k_program, program_enroll_begin_date, school_year',
+        partition_by='k_student, k_program, program_enroll_begin_date, school_year, ed_org_id',
         order_by='last_modified_timestamp desc, pull_timestamp desc'
     ) }}
 )

--- a/models/staging/edfi_3/stage/stg_ef3__student_migrant_education_program_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_migrant_education_program_associations.sql
@@ -4,6 +4,18 @@ with base_stu_programs as (
 
 keyed as (
     select 
+        {{ dbt_utils.generate_surrogate_key(
+            [
+                'tenant_code',
+                'api_year',
+                'lower(student_unique_id)',
+                'ed_org_id',
+                'program_ed_org_id',
+                'lower(program_name)',
+                'lower(program_type)',
+                'program_enroll_begin_date'
+            ]
+        ) }} as k_student_program,
         {{ gen_skey('k_student') }},
         {{ gen_skey('k_student_xyear') }},
         {{ gen_skey('k_program') }},
@@ -18,7 +30,7 @@ keyed as (
 deduped as (
     {{ dbt_utils.deduplicate(
         relation='keyed',
-        partition_by='k_student, k_program, program_enroll_begin_date, school_year, ed_org_id',
+        partition_by='k_student_program',
         order_by='last_modified_timestamp desc, pull_timestamp desc'
     ) }}
 )

--- a/models/staging/edfi_3/stage/stg_ef3__student_program_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_program_associations.sql
@@ -16,7 +16,7 @@ deduped as (
     {{
         dbt_utils.deduplicate(
             relation='keyed',
-            partition_by='k_student, k_program, program_enroll_begin_date, school_year',
+            partition_by='k_student, k_program, program_enroll_begin_date, school_year, ed_org_id',
             order_by='last_modified_timestamp desc, pull_timestamp desc')
     }}
 )

--- a/models/staging/edfi_3/stage/stg_ef3__student_program_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_program_associations.sql
@@ -3,6 +3,18 @@ with base_stu_programs as (
 ),
 keyed as (
     select 
+        {{ dbt_utils.generate_surrogate_key(
+            [
+                'tenant_code',
+                'api_year',
+                'lower(student_unique_id)',
+                'ed_org_id',
+                'program_ed_org_id',
+                'lower(program_name)',
+                'lower(program_type)',
+                'program_enroll_begin_date'
+            ]
+        ) }} as k_student_program,
         {{ gen_skey('k_student') }},
         {{ gen_skey('k_student_xyear') }},
         {{ gen_skey('k_program') }},
@@ -16,7 +28,7 @@ deduped as (
     {{
         dbt_utils.deduplicate(
             relation='keyed',
-            partition_by='k_student, k_program, program_enroll_begin_date, school_year, ed_org_id',
+            partition_by='k_student_program',
             order_by='last_modified_timestamp desc, pull_timestamp desc')
     }}
 )

--- a/models/staging/edfi_3/stage/stg_ef3__student_school_food_service_program_association.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_school_food_service_program_association.sql
@@ -18,7 +18,7 @@ keyed as (
 deduped as (
     {{ dbt_utils.deduplicate(
         relation='keyed',
-        partition_by='k_student, k_program, program_enroll_begin_date, school_year',
+        partition_by='k_student, k_program, program_enroll_begin_date, school_year, ed_org_id',
         order_by='last_modified_timestamp desc, pull_timestamp desc'
     ) }}
 )

--- a/models/staging/edfi_3/stage/stg_ef3__student_school_food_service_program_association.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_school_food_service_program_association.sql
@@ -4,6 +4,18 @@ with base_stu_programs as (
 
 keyed as (
     select 
+        {{ dbt_utils.generate_surrogate_key(
+            [
+                'tenant_code',
+                'api_year',
+                'lower(student_unique_id)',
+                'ed_org_id',
+                'program_ed_org_id',
+                'lower(program_name)',
+                'lower(program_type)',
+                'program_enroll_begin_date'
+            ]
+        ) }} as k_student_program,
         {{ gen_skey('k_student') }},
         {{ gen_skey('k_student_xyear') }},
         {{ gen_skey('k_program') }},
@@ -18,7 +30,7 @@ keyed as (
 deduped as (
     {{ dbt_utils.deduplicate(
         relation='keyed',
-        partition_by='k_student, k_program, program_enroll_begin_date, school_year, ed_org_id',
+        partition_by='k_student_program',
         order_by='last_modified_timestamp desc, pull_timestamp desc'
     ) }}
 )

--- a/models/staging/edfi_3/stage/stg_ef3__student_special_education_program_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_special_education_program_associations.sql
@@ -18,7 +18,7 @@ keyed as (
 deduped as (
     {{ dbt_utils.deduplicate(
         relation='keyed',
-        partition_by='k_student, k_program, program_enroll_begin_date, school_year',
+        partition_by='k_student, k_program, program_enroll_begin_date, school_year, ed_org_id',
         order_by='last_modified_timestamp desc, pull_timestamp desc'
     ) }}
 )

--- a/models/staging/edfi_3/stage/stg_ef3__student_special_education_program_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_special_education_program_associations.sql
@@ -4,6 +4,18 @@ with base_stu_programs as (
 
 keyed as (
     select 
+        {{ dbt_utils.generate_surrogate_key(
+            [
+                'tenant_code',
+                'api_year',
+                'lower(student_unique_id)',
+                'ed_org_id',
+                'program_ed_org_id',
+                'lower(program_name)',
+                'lower(program_type)',
+                'program_enroll_begin_date'
+            ]
+        ) }} as k_student_program,
         {{ gen_skey('k_student') }}, 
         {{ gen_skey('k_student_xyear') }}, 
         {{ gen_skey('k_program') }},
@@ -18,7 +30,7 @@ keyed as (
 deduped as (
     {{ dbt_utils.deduplicate(
         relation='keyed',
-        partition_by='k_student, k_program, program_enroll_begin_date, school_year, ed_org_id',
+        partition_by='k_student_program',
         order_by='last_modified_timestamp desc, pull_timestamp desc'
     ) }}
 )

--- a/models/staging/edfi_3/stage/stg_ef3__student_title_i_part_a_program_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_title_i_part_a_program_associations.sql
@@ -18,7 +18,7 @@ keyed as (
 deduped as (
     {{ dbt_utils.deduplicate(
         relation='keyed',
-        partition_by='k_student, k_program, program_enroll_begin_date, school_year',
+        partition_by='k_student, k_program, program_enroll_begin_date, school_year, ed_org_id',
         order_by='last_modified_timestamp desc, pull_timestamp desc'
     ) }}
 )

--- a/models/staging/edfi_3/stage/stg_ef3__student_title_i_part_a_program_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_title_i_part_a_program_associations.sql
@@ -4,6 +4,18 @@ with base_stu_programs as (
 
 keyed as (
     select 
+        {{ dbt_utils.generate_surrogate_key(
+            [
+                'tenant_code',
+                'api_year',
+                'lower(student_unique_id)',
+                'ed_org_id',
+                'program_ed_org_id',
+                'lower(program_name)',
+                'lower(program_type)',
+                'program_enroll_begin_date'
+            ]
+        ) }} as k_student_program,
         {{ gen_skey('k_student') }},
         {{ gen_skey('k_student_xyear') }},
         {{ gen_skey('k_program') }},
@@ -18,7 +30,7 @@ keyed as (
 deduped as (
     {{ dbt_utils.deduplicate(
         relation='keyed',
-        partition_by='k_student, k_program, program_enroll_begin_date, school_year, ed_org_id',
+        partition_by='k_student_program',
         order_by='last_modified_timestamp desc, pull_timestamp desc'
     ) }}
 )


### PR DESCRIPTION
There are several enhancements/fixes across Student Program Association staging tables in this commit.

1. Added a k_student_program surrogate key to all the student program association staging tables.
2. Critically, modifies the dedupe CTE for all Student Program Associations to dedupe by k_student_program. This fixes a bug in how these models are deduped because they are currently deduping without the entire endpoint PK. This bug surfaces when a Program Ed Org is defined at different level than the Program Association Ed Org and a Student is associated with the same Program at two different Association Ed Orgs. For example, imagine a Program definition at a District level, but a Student within that District is associated with this Program at two different Schools (perhaps they switched Schools midyear), then the current implementation will dedupe these two Association rows down into just one row, even though the Association exists at two different Schools.
3. Adds ed_org_id to pretty much all the tables since this is part of the endpoint PK.
4. For Program Services, there is a fact table in edu_wh that exposes program services for all the programs, but there is a generic program endpoint for which the fact table doesn't include. I have created a staging table for this generic program service.
5. For Disabilities, I have modified an existing disabilities staging table (for spec ed) but also added a disabilities staging table for ed org since disabilities can be on both locations.
6. Exposes Program Participation Statuses into staging tables across all the Student Program Association models (just like Program Services)

