### PR TITLE
Fix invalid reference of stg_ef3__student_program_evaluations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## New features
 ## Under the hood
 ## Fixes
+- Fix invalid reference for relationships test on `stg_ef3__student_program_evaluations`
 
 # edu_edfi_source v0.6.1
 ## Under the hood

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 ## New features
 ## Under the hood
 ## Fixes
+
+
+# edu_edfi_source v0.6.2
+## Fixes
 - Fix invalid reference for relationships test on `stg_ef3__student_program_evaluations`
 
 # edu_edfi_source v0.6.1

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'edu_edfi_source'
-version: '0.6.1'
+version: '0.6.2'
 require-dbt-version: [">=1.0.0", "<2.0.0"]
 
 # This setting configures which "profile" dbt uses for this project.

--- a/models/staging/edfi_3/stage/_edfi_3__stage.yml
+++ b/models/staging/edfi_3/stage/_edfi_3__stage.yml
@@ -81,7 +81,7 @@ referential_integrity_tests:
 
   - k_program_evaluation: &ref_k_program_evaluation
     - relationships:
-        to: ref('stg_edf3__student_program_evaluations')
+        to: ref('stg_ef3__student_program_evaluations')
         field: k_program_evaluation
         tags: ['ref_integrity']
 


### PR DESCRIPTION
In an earlier PR, I introduced an invalid reference (typo) of `stg_ef3__student_program_evaluations` in a referential integrity test.

I tested this change by pointing my local `stadium_georgia` project to a local `edu_wh`, which installed a local `edu_edfi_source`, which contained the fix. Running `dbt build` shows that the test is found and executes as expected, rather than logging the warning.