### PR TITLE
Update base and stg exam results and stg exams, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Unreleased
 ## New features
-- Add the following TPDM/EPDM base and stage models:
-  - base_epdm__certification_exams
+- Update the following TPDM/EPDM base and stage models:
   - base_epdm__certification_exam_results
   - stg_epdm__certification_exams
   - stg_epdm__certification_exam_results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Unreleased
 ## New features
+- Add the following TPDM/EPDM base and stage models:
+  - base_epdm__certification_exams
+  - base_epdm__certification_exam_results
+  - stg_epdm__certification_exams
+  - stg_epdm__certification_exam_results
 ## Under the hood
 ## Fixes
-
-# edu_edfi_source v0.6.1
-## Under the hood
-- `extract_descriptor()` macro now correctly handles descriptors in cases where the field name doesn't match the underlying descriptor code (e.g. birthCountryDescriptor -> countryDescriptor)
 
 # edu_edfi_source v0.6.0
 ## New features

--- a/models/staging/tpdm/base/base_tpdm__certification_exam_results.sql
+++ b/models/staging/tpdm/base/base_tpdm__certification_exam_results.sql
@@ -21,7 +21,9 @@ renamed as (
         -- non-identity components
         v:attemptNumber::int                      as attempt_number,
         v:certificationExamPassIndicator::boolean as certification_exam_pass_indicator,
+        v:certificationExamScore::number as certification_exam_score,
         -- descriptors
+        {{ extract_descriptor('v:certificationExamStatus::string') }} as certification_exam_status_descriptor,
         {{ extract_descriptor('v:personReference:sourceSystemDescriptor::string') }} as person_source_system_descriptor,
         -- references
         v:certificationExamReference as certification_exam_reference,

--- a/models/staging/tpdm/base/base_tpdm__certification_exam_results.sql
+++ b/models/staging/tpdm/base/base_tpdm__certification_exam_results.sql
@@ -23,7 +23,7 @@ renamed as (
         v:certificationExamPassIndicator::boolean as certification_exam_pass_indicator,
         v:certificationExamScore::number as certification_exam_score,
         -- descriptors
-        {{ extract_descriptor('v:certificationExamStatus::string') }} as certification_exam_status_descriptor,
+        {{ extract_descriptor('v:certificationExamStatusDescriptor::string') }} as certification_exam_status_descriptor,
         {{ extract_descriptor('v:personReference:sourceSystemDescriptor::string') }} as person_source_system_descriptor,
         -- references
         v:certificationExamReference as certification_exam_reference,

--- a/models/staging/tpdm/stage/stg_tpdm__certification_exam_results.sql
+++ b/models/staging/tpdm/stage/stg_tpdm__certification_exam_results.sql
@@ -14,7 +14,8 @@ keyed as (
         ) }} as k_certification_exam_result,
         {{ gen_skey('k_person') }},
         {{ gen_skey('k_certification_exam') }},
-        certification_exam_results.*
+        certification_exam_results.*,
+        certification_exam_results.api_year as school_year
         {{ extract_extension(model_name=this.name, flatten=True) }}
     from certification_exam_results
 ),

--- a/models/staging/tpdm/stage/stg_tpdm__certification_exams.sql
+++ b/models/staging/tpdm/stage/stg_tpdm__certification_exams.sql
@@ -9,7 +9,8 @@ keyed as (
             'lower(certification_exam_id)',
             'lower(namespace)']
         ) }} as k_certification_exam,
-        certification_exams.*
+        certification_exams.*,
+        certification_exams.api_year as school_year
         {{ extract_extension(model_name=this.name, flatten=True) }}
     from certification_exams
 ),


### PR DESCRIPTION
This PR will update the following TPDM/EPDM base and stage models to support the corresponding warehouse models.:

- `base_epdm__certification_exam_results`: add school_year, certifiation_exam_status_descriptor, certification_exam_score
- `stg_epdm__certification_exams`: add  school_year
- `stg_epdm__certification_exam_results`: add school_year
