### PR TITLE
Hotfix/Descriptor name in stg_ef3__stu_program__program_services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-# edu_edfi_source v0.6.5
+# Unreleased
 ## New features
 ## Under the hood
+## Fixes
+
+# edu_edfi_source v0.6.5
 ## Fixes
  - Fixed the `program_service` column in `stg_ef3__stu_program__program_services`, which read the nonexistent `programServiceDescriptor` field and always resolved to null. It now reads `serviceDescriptor`, matching the actual Ed-Fi `services` collection.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-# Unreleased
+# edu_edfi_source v0.6.5
 ## New features
 ## Under the hood
 ## Fixes
+ - Fixed the `program_service` column in `stg_ef3__stu_program__program_services`, which read the nonexistent `programServiceDescriptor` field and always resolved to null. It now reads `serviceDescriptor`, matching the actual Ed-Fi `services` collection.
 
 # edu_edfi_source v0.6.4
 ## New features

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'edu_edfi_source'
-version: '0.6.4'
+version: '0.6.5'
 require-dbt-version: [">=1.0.0", "<2.0.0"]
 
 # This setting configures which "profile" dbt uses for this project.

--- a/models/staging/edfi_3/stage/stg_ef3__stu_program__program_services.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_program__program_services.sql
@@ -16,7 +16,7 @@ flattened as (
 
         program_enroll_begin_date,
         program_enroll_end_date,
-        {{ extract_descriptor('value:programServiceDescriptor::string') }} as program_service,
+        {{ extract_descriptor('value:serviceDescriptor::string') }} as program_service,
         value:primaryIndicator::boolean as primary_indicator,
         value:serviceBeginDate::date    as service_begin_date,
         value:serviceEndDate::date      as service_end_date,


### PR DESCRIPTION
## Description & motivation

This PR fixes the `program_service` column in `stg_ef3__stu_program__program_services`, which was reading a JSON field that does not exist on the Ed-Fi `services` collection, so the column resolved to null for every row.

The `services` json payload actually carries a `serviceDescriptor` field, not a `programServiceDescriptor` field. 

---

## PR Merge Priority:
- [ ] Low
- [ ] Medium
- [x] High - `program_service` is currently null and breaking an EDU implementation.

---

## Changes to existing files:

- `stg_ef3__stu_program__program_services.sql`: Changed the `program_service` extraction from `value:programServiceDescriptor` --> `value:serviceDescriptor`. 

---

## Bug description

The model flattens `v_services` and extracts the descriptor for each service. The prior code pointed at `programServiceDescriptor`, which is not a valid key of a `services` element, so the extraction returned null which causses errors downstream.

```sql
-- Before:
{{ extract_descriptor('value:programServiceDescriptor::string') }} as program_service,  -- <-- Bug: field does not exist on a services element, always null.

-- After:
{{ extract_descriptor('value:serviceDescriptor::string') }} as program_service,
```

**Before:**

| k_student_program | program_service | primary_indicator | service_begin_date |
|-------------------|-----------------|-------------------|--------------------|
| abc123            | _(null)_        | true              | 2025-08-15         |

**After:**

| k_student_program | program_service   | primary_indicator | service_begin_date |
|-------------------|-------------------|-------------------|--------------------|
| abc123            | Regular education | true              | 2025-08-15         |


---

## Tests and QC done:

- [x] Compiled `stg_ef3__stu_program__program_services` without errors.
- [x] Confirmed `program_service` is now populated.