### PR TITLE
Change person_id type from int to string

### DIFF
--- a/models/staging/edfi_3/base/base_ef3__people.sql
+++ b/models/staging/edfi_3/base/base_ef3__people.sql
@@ -13,7 +13,7 @@ renamed as (
 
         v:id::string as record_guid,
         -- identity components
-        v:personId::int as person_id,
+        v:personId::string as person_id,
         {{ extract_descriptor('v:sourceSystemDescriptor::string') }} as source_system
     from people
 )


### PR DESCRIPTION
PersonId is a string, not an int. 
https://edfidocs.blob.core.windows.net/$web/handbook/v6.0/index.html#/Person91c8b3fb-97a3-4e3e-99ef-256595a0c868