### PR TITLE
Feature/Section 504 and Neglected or Delinquent programs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 ## New features
-- Add base and stage models for `student_section_504_program_associations` and `student_neglected_or_delinquent_program_associations`
+- Add base and stage models for `student_section_504_program_associations` and `student_neglected_or_delinquent_program_associations`. Disable these programs by setting `'src:program:section_504:enabled': False` and `'src:program:neglected_or_delinquent:enabled': False` if necessary
 ## Under the hood
 ## Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 ## New features
+- Add base and stage models for `student_section_504_program_associations` and `student_neglected_or_delinquent_program_associations`
 ## Under the hood
 ## Fixes
 

--- a/models/staging/edfi_3/base/_edfi_3__base.yml
+++ b/models/staging/edfi_3/base/_edfi_3__base.yml
@@ -154,6 +154,10 @@ models:
     config:
       tags: ['migrant_education']
       enabled: "{{ var('src:program:migrant_education:enabled', True) }}"
+  - name: base_ef3__student_neglected_or_delinquent_program_associations
+    config:
+      tags: ['neglected_or_delinquent']
+      enabled: "{{ var('src:program:neglected_or_delinquent:enabled', True) }}"
   - name: base_ef3__student_parent_associations
     config:
       tags: ['core']
@@ -173,6 +177,10 @@ models:
     config:
       tags: ['food_service']
       enabled: "{{ var('src:program:food_service:enabled', True) }}"
+  - name: base_ef3__student_section_504_program_associations
+    config:
+      tags: ['section_504']
+      enabled: "{{ var('src:program:section_504:enabled', True) }}"
   - name: base_ef3__student_section_associations
     config:
       tags: ['core']

--- a/models/staging/edfi_3/base/base_ef3__student_neglected_or_delinquent_program_associations.sql
+++ b/models/staging/edfi_3/base/base_ef3__student_neglected_or_delinquent_program_associations.sql
@@ -1,0 +1,50 @@
+with source_stu_programs as (
+    {{ source_edfi3('student_neglected_or_delinquent_program_associations') }}
+),
+
+renamed as (
+    select
+        -- generic columns
+        tenant_code,
+        api_year,
+        pull_timestamp,
+        last_modified_timestamp,
+        file_row_number,
+        filename,
+        is_deleted,
+
+        v:id::string                                                         as record_guid, 
+        ods_version, 
+        data_model_version, 
+        v:studentReference:studentUniqueId::string                           as student_unique_id, 
+        v:educationOrganizationReference:educationOrganizationId::int        as ed_org_id,
+        v:educationOrganizationReference:link:rel::string                    as ed_org_type,
+        v:beginDate::date                                                    as program_enroll_begin_date,
+        v:endDate::date                                                      as program_enroll_end_date, 
+        v:programReference:programName::string                               as program_name,
+        v:programReference:educationOrganizationId::integer                  as program_ed_org_id,
+
+        v:servedOutsideOfRegularSession::boolean                             as served_outside_of_regular_session,
+
+        -- descriptors
+        {{ extract_descriptor('v:programReference:programTypeDescriptor') }} as program_type,
+        {{ extract_descriptor('v:elaProgressLevelDescriptor') }}             as ela_progress_level_descriptor,
+        {{ extract_descriptor('v:mathematicsProgressLevelDescriptor') }}     as mathematics_progress_level_descriptor,
+        {{ extract_descriptor('v:neglectedOrDelinquentProgramDescriptor') }} as neglected_or_delinquent_program_descriptor,
+        {{ extract_descriptor('v:reasonExitedDescriptor') }}                 as reason_exited_descriptor,
+
+        -- references
+        v:educationOrganizationReference                                     as education_organization_reference,
+        v:programReference                                                   as program_reference, 
+        v:studentReference                                                   as student_reference,
+
+        -- lists
+        v:neglectedOrDelinquentProgramServices                               as v_neglected_or_delinquent_program_services,
+        v:programParticipationStatuses                                       as v_program_participation_statuses,
+
+        -- edfi extensions
+        v:_ext                                                               as v_ext
+    from source_stu_programs
+)
+
+select * from renamed

--- a/models/staging/edfi_3/base/base_ef3__student_neglected_or_delinquent_program_associations.sql
+++ b/models/staging/edfi_3/base/base_ef3__student_neglected_or_delinquent_program_associations.sql
@@ -28,10 +28,10 @@ renamed as (
 
         -- descriptors
         {{ extract_descriptor('v:programReference:programTypeDescriptor') }} as program_type,
-        {{ extract_descriptor('v:elaProgressLevelDescriptor') }}             as ela_progress_level_descriptor,
-        {{ extract_descriptor('v:mathematicsProgressLevelDescriptor') }}     as mathematics_progress_level_descriptor,
-        {{ extract_descriptor('v:neglectedOrDelinquentProgramDescriptor') }} as neglected_or_delinquent_program_descriptor,
-        {{ extract_descriptor('v:reasonExitedDescriptor') }}                 as reason_exited_descriptor,
+        {{ extract_descriptor('v:elaProgressLevelDescriptor') }}             as ela_progress_level,
+        {{ extract_descriptor('v:mathematicsProgressLevelDescriptor') }}     as mathematics_progress_level,
+        {{ extract_descriptor('v:neglectedOrDelinquentProgramDescriptor') }} as neglected_or_delinquent_program,
+        {{ extract_descriptor('v:reasonExitedDescriptor') }}                 as reason_exited,
 
         -- references
         v:educationOrganizationReference                                     as education_organization_reference,

--- a/models/staging/edfi_3/base/base_ef3__student_section_504_program_associations.sql
+++ b/models/staging/edfi_3/base/base_ef3__student_section_504_program_associations.sql
@@ -1,0 +1,51 @@
+with source_stu_programs as (
+    {{ source_edfi3('student_section504_program_associations') }}
+),
+
+renamed as (
+    select
+        -- generic columns
+        tenant_code,
+        api_year,
+        pull_timestamp,
+        last_modified_timestamp,
+        file_row_number,
+        filename,
+        is_deleted,
+
+        v:id::string                                                         as record_guid, 
+        ods_version, 
+        data_model_version, 
+        v:studentReference:studentUniqueId::string                           as student_unique_id, 
+        v:educationOrganizationReference:educationOrganizationId::int        as ed_org_id,
+        v:educationOrganizationReference:link:rel::string                    as ed_org_type,
+        v:beginDate::date                                                    as program_enroll_begin_date,
+        v:endDate::date                                                      as program_enroll_end_date, 
+        v:programReference:programName::string                               as program_name,
+        v:programReference:educationOrganizationId::integer                  as program_ed_org_id,
+
+        v:accommodationPlan::boolean                                         as accommodation_plan, 
+        v:section504Eligibility::boolean                                     as section_504_eligibility, 
+        v:servedOutsideOfRegularSession::boolean                             as served_outside_of_regular_session,
+    
+        v:section504EligibilityDecisionDate::date                            as section_504_eligibility_decision_date, 
+        v:section504MeetingDate::date                                        as section_504_meeting_date,
+        -- descriptors
+        {{ extract_descriptor('v:programReference:programTypeDescriptor') }} as program_type,
+        {{ extract_descriptor('v:reasonExitedDescriptor') }}                 as reason_exited_descriptor,
+        {{ extract_descriptor('v:section504DisabilityDescriptor') }}         as section_504_disability_descriptor,
+
+        -- references
+        v:educationOrganizationReference                                     as education_organization_reference,
+        v:programReference                                                   as program_reference, 
+        v:studentReference                                                   as student_reference,
+
+        -- lists
+        v:programParticipationStatuses                                       as v_program_participation_statuses,
+
+        -- edfi extensions
+        v:_ext                                                               as v_ext
+    from source_stu_programs
+)
+
+select * from renamed

--- a/models/staging/edfi_3/base/base_ef3__student_section_504_program_associations.sql
+++ b/models/staging/edfi_3/base/base_ef3__student_section_504_program_associations.sql
@@ -32,8 +32,8 @@ renamed as (
         v:section504MeetingDate::date                                        as section_504_meeting_date,
         -- descriptors
         {{ extract_descriptor('v:programReference:programTypeDescriptor') }} as program_type,
-        {{ extract_descriptor('v:reasonExitedDescriptor') }}                 as reason_exited_descriptor,
-        {{ extract_descriptor('v:section504DisabilityDescriptor') }}         as section_504_disability_descriptor,
+        {{ extract_descriptor('v:reasonExitedDescriptor') }}                 as reason_exited,
+        {{ extract_descriptor('v:section504DisabilityDescriptor') }}         as section_504_disability,
 
         -- references
         v:educationOrganizationReference                                     as education_organization_reference,

--- a/models/staging/edfi_3/stage/_edfi_3__stage.yml
+++ b/models/staging/edfi_3/stage/_edfi_3__stage.yml
@@ -614,6 +614,16 @@ models:
       tags: ['language_instruction']
       enabled: "{{ var('src:program:language_instruction:enabled', True) }}"
 
+  - name: stg_ef3__stu_neglected_delinquent__program_services
+    config: 
+      tags: ['neglected_or_delinquent']
+      enabled: "{{ var('src:program:neglected_or_delinquent:enabled', True) }}"
+
+  - name: stg_ef3__stu_neglected_delinquent__program_participation_statuses
+    config: 
+      tags: ['neglected_or_delinquent']
+      enabled: "{{ var('src:program:neglected_or_delinquent:enabled', True) }}"
+
   - name: stg_ef3__stu_migrant_edu__program_services
     config: 
       tags: ['migrant_education']
@@ -641,6 +651,11 @@ models:
     config: 
       tags: ['food_service']
       enabled: "{{ var('src:program:food_service:enabled', True) }}"
+
+  - name: stg_ef3__stu_section_504__program_services
+    config: 
+      tags: ['section_504']
+      enabled: "{{ var('src:program:section_504:enabled', True) }}"
 
   - name: stg_ef3__stu_spec_ed__disabilities
     config:
@@ -805,6 +820,11 @@ models:
       tags: ['migrant_education']
       enabled: "{{ var('src:program:migrant_education:enabled', True) }}"
 
+  - name: stg_ef3__student_neglected_or_delinquent_program_associations
+    config: 
+      tags: ['neglected_or_delinquent']
+      enabled: "{{ var('src:program:neglected_or_delinquent:enabled', True) }}"
+
   - name: stg_ef3__student_objective_assessments
     config:
       tags: ['assessment']
@@ -889,6 +909,11 @@ models:
     config: 
       tags: ['food_service']
       enabled: "{{ var('src:program:food_service:enabled', True) }}"
+
+  - name: stg_ef3__student_section_504_program_association
+    config: 
+      tags: ['section_504']
+      enabled: "{{ var('src:program:section_504:enabled', True) }}"
 
   - name: stg_ef3__student_section_associations
     config:

--- a/models/staging/edfi_3/stage/_edfi_3__stage.yml
+++ b/models/staging/edfi_3/stage/_edfi_3__stage.yml
@@ -652,7 +652,7 @@ models:
       tags: ['food_service']
       enabled: "{{ var('src:program:food_service:enabled', True) }}"
 
-  - name: stg_ef3__stu_section_504__program_services
+  - name: stg_ef3__stu_section_504__program_participation_statuses
     config: 
       tags: ['section_504']
       enabled: "{{ var('src:program:section_504:enabled', True) }}"
@@ -910,7 +910,7 @@ models:
       tags: ['food_service']
       enabled: "{{ var('src:program:food_service:enabled', True) }}"
 
-  - name: stg_ef3__student_section_504_program_association
+  - name: stg_ef3__student_section_504_program_associations
     config: 
       tags: ['section_504']
       enabled: "{{ var('src:program:section_504:enabled', True) }}"

--- a/models/staging/edfi_3/stage/stg_ef3__stu_neglected_delinquent__program_participation_statuses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_neglected_delinquent__program_participation_statuses.sql
@@ -1,0 +1,31 @@
+with stage_stu_programs as (
+    select * from {{ ref('stg_ef3__student_neglected_or_delinquent_program_associations') }}
+),
+
+flattened as (
+    select
+        k_student_program,
+        tenant_code,
+        api_year,
+        k_student,
+        k_student_xyear,
+        k_program,
+        k_lea,
+        k_school,
+        ed_org_id,
+
+        program_enroll_begin_date,
+        program_enroll_end_date,
+        {{ extract_descriptor('value:participationStatusDescriptor::string') }} as participation_status,
+        value:statusBeginDate::date     as status_begin_date,
+        value:designatedBy::string      as designated_by,
+        value:statusEndDate::date       as status_end_date,
+
+        -- edfi extensions
+        value:_ext as v_ext
+
+    from stage_stu_programs
+        {{ json_flatten('v_program_participation_statuses') }}
+)
+
+select * from flattened

--- a/models/staging/edfi_3/stage/stg_ef3__stu_neglected_delinquent__program_services.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_neglected_delinquent__program_services.sql
@@ -1,0 +1,32 @@
+with stage_stu_programs as (
+    select * from {{ ref('stg_ef3__student_neglected_or_delinquent_program_associations') }}
+),
+
+flattened as (
+    select
+        k_student_program,
+        tenant_code,
+        api_year,
+        k_student,
+        k_student_xyear,
+        k_program,
+        k_lea,
+        k_school,
+        ed_org_id,
+
+        program_enroll_begin_date,
+        program_enroll_end_date,
+        {{ extract_descriptor('value:neglectedOrDelinquentProgramServiceDescriptor') }} as program_service,
+        value:primaryIndicator::boolean as primary_indicator,
+        value:providers                 as v_providers,
+        value:serviceBeginDate::date    as service_begin_date,
+        value:serviceEndDate::date      as service_end_date,
+
+        -- edfi extensions
+        value:_ext as v_ext
+
+    from stage_stu_programs
+        {{ json_flatten('v_neglected_or_delinquent_program_services') }}
+)
+
+select * from flattened

--- a/models/staging/edfi_3/stage/stg_ef3__stu_section_504__program_participation_statuses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__stu_section_504__program_participation_statuses.sql
@@ -1,0 +1,31 @@
+with stage_stu_programs as (
+    select * from {{ ref('stg_ef3__student_section_504_program_associations') }}
+),
+
+flattened as (
+    select
+        k_student_program,
+        tenant_code,
+        api_year,
+        k_student,
+        k_student_xyear,
+        k_program,
+        k_lea,
+        k_school,
+        ed_org_id,
+
+        program_enroll_begin_date,
+        program_enroll_end_date,
+        {{ extract_descriptor('value:participationStatusDescriptor::string') }} as participation_status,
+        value:statusBeginDate::date     as status_begin_date,
+        value:designatedBy::string      as designated_by,
+        value:statusEndDate::date       as status_end_date,
+
+        -- edfi extensions
+        value:_ext as v_ext
+
+    from stage_stu_programs
+        {{ json_flatten('v_program_participation_statuses') }}
+)
+
+select * from flattened

--- a/models/staging/edfi_3/stage/stg_ef3__student_neglected_or_delinquent_program_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_neglected_or_delinquent_program_associations.sql
@@ -1,0 +1,39 @@
+with base_stu_programs as (
+    select * from {{ ref('base_ef3__student_neglected_or_delinquent_program_associations') }}
+),
+
+keyed as (
+    select 
+        {{ dbt_utils.generate_surrogate_key(
+            [
+                'tenant_code',
+                'api_year',
+                'lower(student_unique_id)',
+                'ed_org_id',
+                'program_ed_org_id',
+                'lower(program_name)',
+                'lower(program_type)',
+                'program_enroll_begin_date'
+            ]
+        ) }} as k_student_program,
+        {{ gen_skey('k_student') }},
+        {{ gen_skey('k_student_xyear') }},
+        {{ gen_skey('k_program') }},
+        {{ edorg_ref(annualize=False) }},
+        api_year as school_year,
+        base_stu_programs.*
+        {{ extract_extension(model_name=this.name, flatten=True) }}
+
+    from base_stu_programs
+),
+
+deduped as (
+    {{ dbt_utils.deduplicate(
+        relation='keyed',
+        partition_by='k_student_program',
+        order_by='last_modified_timestamp desc, pull_timestamp desc'
+    ) }}
+)
+
+select * from deduped
+where not is_deleted

--- a/models/staging/edfi_3/stage/stg_ef3__student_section_504_program_associations.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__student_section_504_program_associations.sql
@@ -1,0 +1,39 @@
+with base_stu_programs as (
+    select * from {{ ref('base_ef3__student_section_504_program_associations') }}
+),
+
+keyed as (
+    select 
+        {{ dbt_utils.generate_surrogate_key(
+            [
+                'tenant_code',
+                'api_year',
+                'lower(student_unique_id)',
+                'ed_org_id',
+                'program_ed_org_id',
+                'lower(program_name)',
+                'lower(program_type)',
+                'program_enroll_begin_date'
+            ]
+        ) }} as k_student_program,
+        {{ gen_skey('k_student') }},
+        {{ gen_skey('k_student_xyear') }},
+        {{ gen_skey('k_program') }},
+        {{ edorg_ref(annualize=False) }},
+        api_year as school_year,
+        base_stu_programs.*
+        {{ extract_extension(model_name=this.name, flatten=True) }}
+
+    from base_stu_programs
+),
+
+deduped as (
+    {{ dbt_utils.deduplicate(
+        relation='keyed',
+        partition_by='k_student_program',
+        order_by='last_modified_timestamp desc, pull_timestamp desc'
+    ) }}
+)
+
+select * from deduped
+where not is_deleted


### PR DESCRIPTION
## Description & motivation
Adds staging models for new types of programs. Section 504 is used in WI and Neglected or Delinquent is the only other Ed-Fi program type we haven't yet added to EDU.
Dependency of https://github.com/edanalytics/edu_wh/pull/273

## Breaking changes introduced by this PR:
If a project does not have these resources in their `src_edfi3.yml` file, they will have to disable the programs in order for dbt to compile:
`'src:program:section_504:enabled': False`
`'src:program:neglected_or_delinquent:enabled': False`

## PR Merge Priority:
- [x] Low
- [ ] Medium
- [ ] High

## Changes to existing files:
Added tags and enabled variables to the base and stage yml files

## New files created:
Added the standard base and stage models for both program types, following the convention of previously added programs. Section 504 does not have a list of program services per the handbook.

## Tests and QC done:
Ran successfully in WDL and spot checked the stage models. I also removed the resources from my `src_edfi3.yml` and confirmed that dbt ran successfully if I disabled both programs.