### PR TITLE
user lower case assess ids to join between stg_ef3__assess + stg_ef3_…

### DIFF
--- a/models/staging/edfi_3/intermediate/int_ef3__student_assessments__identify_subject.sql
+++ b/models/staging/edfi_3/intermediate/int_ef3__student_assessments__identify_subject.sql
@@ -48,7 +48,7 @@ adding_subject as (
         coalesce(subject_xwalk.academic_subject, stg_assessments_single_subj.academic_subject) as academic_subject
     from base_stu_assessments
     left join score_result_to_subject
-        on base_stu_assessments.assessment_identifier = score_result_to_subject.assessment_identifier
+        on lower(base_stu_assessments.assessment_identifier) = lower(score_result_to_subject.assessment_identifier)
         and base_stu_assessments.namespace = score_result_to_subject.namespace
         and base_stu_assessments.student_assessment_identifier = score_result_to_subject.student_assessment_identifier
         and base_stu_assessments.tenant_code = score_result_to_subject.tenant_code
@@ -56,11 +56,11 @@ adding_subject as (
         and base_stu_assessments.pull_timestamp = score_result_to_subject.pull_timestamp
         and base_stu_assessments.file_row_number = score_result_to_subject.file_row_number
     left join subject_xwalk
-        on score_result_to_subject.assessment_identifier = subject_xwalk.assessment_identifier
+        on lower(score_result_to_subject.assessment_identifier) = lower(subject_xwalk.assessment_identifier)
         and score_result_to_subject.namespace = subject_xwalk.namespace
         and score_result_to_subject.score_result = subject_xwalk.score_result
     left join stg_assessments_single_subj
-        on base_stu_assessments.assessment_identifier = stg_assessments_single_subj.assessment_identifier
+        on lower(base_stu_assessments.assessment_identifier) = lower(stg_assessments_single_subj.assessment_identifier)
         and base_stu_assessments.namespace = stg_assessments_single_subj.namespace
         and base_stu_assessments.tenant_code = stg_assessments_single_subj.tenant_code
         and base_stu_assessments.api_year = stg_assessments_single_subj.api_year


### PR DESCRIPTION
<!---
Provide Title above, ensure it summarizes the work in the PR. Example PR titles templates:
* "feature/ (or build/): describe new functionality"
* "hotfix/: describe issue fix for immediate release"
* "bugfix/ (or fix/): describe issue fix, not necessary for immediate release"
* "docs/: adding or updating documentation"
-->

## Description & motivation
<!---
High level description your PR, and why you're making it. Is this linked to slack thread, Monday board, open
issue, a continuation to a previous PR? Link it here if relevant (use the "#" symbol for issues/PRs).
-->
[JIRA ticket](https://edanalytics.atlassian.net/browse/STADIUM-444)

A handful of student assessments are being dropped from `stg_ef3__student_assessments` with [this ](https://github.com/edanalytics/edu_edfi_source/blob/304506aeba5cc282e68e6a7094a5bc699f14423a/models/staging/edfi_3/stage/stg_ef3__student_assessments.sql#L32)filter `where academic_subject is not null`.

This `academic_subject` is evaluated [here](https://github.com/edanalytics/edu_edfi_source/blob/304506aeba5cc282e68e6a7094a5bc699f14423a/models/staging/edfi_3/intermediate/int_ef3__student_assessments__identify_subject.sql#L48), where it is null only when there are no matching assessment_identifiers/tenant/api_year/namespace combinations between `stg_ef3__assessments` and `base_ef3__student_assessments`. 

For some cases, there are duplicates in `stg_ef3__assessments` with 2 differing letter cases of the same `assessment_identifier`.  e.g. `IB - Psychology` and `IB - PYSCHOLOGY`. But since `k_assessment` is made up of `lower(assessment_identifier)`, the [final dedupe](https://github.com/edanalytics/edu_edfi_source/blob/304506aeba5cc282e68e6a7094a5bc699f14423a/models/staging/edfi_3/stage/stg_ef3__assessments.sql#L27) randomly picks either of these records --sometimes landing on the `assessment_identifier` with a letter case different from the `assessment_identifier` value from `base_ef3__student_assessments`


## PR Merge Priority:
<!---
This checklist helps the reviewers understand the level of priority for merging this PR.
A loose description of merging priority levels is:
Low: A week or more.
Medium: Within 3 days or less.
High: As soon as possible.
-->
- [x] Low
- [ ] Medium
- [ ] High

<!---
If High Priority, explain why as a comment below.
-->

## Changes to existing files:
<!---
Include this section if you are changing any existing files or creating breaking changes to existing files. Label the model name and describe the logic behind the changes made, try to be very descriptive here. For example:
- `stg_model` : Describe any changes made to `stg_model` and why the changes where made.
- `src_staging` : Describe any changes made to `src_staging` and why the changes where made.
-->
- `dim_assessment`: change `school_year` to `api_year` in coalesce and dedupe so we are using `api_year` to attach to any `k_assessment`.

## New files created:
<!---
Include this section if you are creating any new files. Label the model name and describe the logic behind the changes made, try to be very descriptive here. For example:
- `stg_new_model` : Describe the purpose of `stg_new_model` and the logic behind creating the model.
- `src_new_staging` : Describe the purpose of `src_new_staging`.
-->

## Tests and QC done:
<!---
Describe any process that confirms that the files do what is expected, include screenshots if relevant. For example:
- Analyst replication confirmed that updates to `stg_model` new counts were correct.
- Executed a dbt project run and ensured it was successful.
-->
I ran `dbt run -s +stg_ef3__assessments+ +stg_ef3__student_assessments+ --full-refresh ` in my schema.  It is also important to note that my `bld_ef3__student_assessment_cross_tenant` model is ahead of prod during time of QC. Below are the QC queries I ran to test this out:

```
select count(*) from  dev_analytics.dev_nn_wh.dim_assessment; --136997
select count(*) from prod_wh.dim_assessment; --136968

-- There is a 29 row difference between prod and dev

select * from dev_analytics.dev_nn_wh.dim_assessment dev where not exists 
    (
        select * from prod_wh.dim_assessment prod
        where dev.k_assessment = prod.k_assessment
    );


select * from prod_wh.dim_assessment prod where not exists 
    (
        select * from dev_analytics.dev_nn_wh.dim_assessment dev
        where dev.k_assessment = prod.k_assessment
    );

-- No `k_assessment`s records were dropped. 
-- Data difference between dev and prod is due to either differing build times + fake tenant data


select * from prod_wh.dim_assessment prod where not exists 
    (
        select * from dev_analytics.dev_nn_wh.dim_assessment dev
        where dev.k_assessment = prod.k_assessment 
                and dev.school_year = prod.school_year

    );

-- This new change effectively affects the `school_year` field of 529 rows

select * from prod_wh.dim_assessment prod where not exists 
    (
        select * from dev_analytics.dev_nn_wh.dim_assessment dev
        where dev.k_assessment = prod.k_assessment 
                and dev.school_year = prod.school_year

    );

-- With this query, it shows that with this change, `dim_assessment` actually is picking up the correct years for each `k_assessment`

select * from dev_analytics.dev_nn_wh.dim_assessment dev where not exists 
    (
        select * from prod_stage.stg_ef3__assessments prod
        where dev.k_assessment = prod.k_assessment
        and dev.school_year = prod.api_year
    ) and not exists (

    select * from DEV_ANALYTICS.dev_nn_build.bld_ef3__student_assessment_cross_tenant prod_1
        where dev.k_assessment = prod_1.k_assessment
        and dev.school_year = prod_1.api_year
    );

select * from prod_wh.dim_assessment dev where not exists 
    (
        select * from prod_stage.stg_ef3__assessments prod
        where dev.k_assessment = prod.k_assessment
        and dev.school_year = prod.api_year
    ) and not exists (

    select * from DEV_ANALYTICS.dev_nn_build.bld_ef3__student_assessment_cross_tenant prod_1
        where dev.k_assessment = prod_1.k_assessment
        and dev.school_year = prod_1.api_year
    );


-- Checking `fct_student_assessment` , the table looks overall healthy, with the only data difference between dev and prod coming from the `cougar_scdemulti` fake tenant

select
  prod.k_student_assessment is not null as in_prod,
  dev.k_student_assessment is not null as in_dev,
  count(*)
from analytics.prod_wh.fct_student_assessment prod
full outer join dev_analytics.dev_nn_wh.fct_student_assessment dev
 on prod.k_student_assessment = dev.k_student_assessment
group by all
; 

select * from prod_wh.fct_student_assessment prod
where not exists (
    select 1 from dev_analytics.dev_nn_wh.fct_student_assessment dev
    where prod.k_student_assessment = dev.k_student_assessment
) ;

```

## edu_edfi_source PR Review Checklist:
Make sure the following have been completed before approving this PR:
- [ ] Description of changes has been added to Unreleased section of [CHANGELOG.md](/CHANGELOG.md). Add under `## New Features` for features, etc.
- [ ] Code has been tested/checked for Databricks and Snowflake compatibility - EA engineers see Databricks checklist [here](https://edanalytics.slite.com/app/docs/LRjXFxVRAWA5ST) 
- [ ] Reviewer confirms the grain of all tables are unchanged, OR any changes are expected, communicated, and this PR is flagged as a breaking change (not for patch release)
- [ ] If a new configuration xwalk was added:
  - [ ] The code is written such that the xwalk is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the xwalk is required, and the required xwalk is added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new xwalk has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_xwalks.md) 
- [ ] If a new configuration variable was added:
  - [ ] The code is written such that the variable is optional (preferred), and this behavior was tested, OR
  - [ ] The code is written such that the variable is required, and a default value was added to edu_project_template, and this PR is flagged as breaking change (not for patch release)
  - [ ] A description for the new variable has been added to EDU documentation site [here](https://github.com/edanalytics/edu_docs/blob/main/docs/docs/manage_extend/reference/configure_dbt_vars.md) 

<!---## Future ToDos & Questions:-->
<!---
[Optional] Include any future steps and questions related to this PR.
-->
