### PR TITLE
Fix survey model keys and references.

### DIFF
--- a/macros/gen_skey.sql
+++ b/macros/gen_skey.sql
@@ -197,12 +197,12 @@
         },
         'k_survey_question': {
             'reference_name': 'survey_question_reference',
-            'col_list': ['questionCode', 'surveyIdentifier'],
+            'col_list': ['namespace', 'questionCode', 'surveyIdentifier'],
             'annualize': True
         },
         'k_survey_response': {
             'reference_name': 'survey_response_reference',
-            'col_list': ['surveyIdentifier', 'surveyResponseIdentifier'],
+            'col_list': ['namespace', 'surveyIdentifier', 'surveyResponseIdentifier'],
             'annualize': True
         },
         'k_learning_standard': {

--- a/models/staging/edfi_3/base/base_ef3__surveys.sql
+++ b/models/staging/edfi_3/base/base_ef3__surveys.sql
@@ -20,8 +20,8 @@ renamed as (
         v:educationOrganizationReference:educationOrganizationId::int as ed_org_id,
         v:educationOrganizationReference:link:rel::string             as ed_org_type,
         v:surveyTitle::string                                         as survey_title,
-        v:sessionReference:school_id::string                          as school_id,
-        v:sessionReference:session_name::string                       as session_name,
+        v:sessionReference:schoolId::string                           as school_id,
+        v:sessionReference:sessionName::string                        as session_name,
         v:numberAdministered::int                                     as number_administered,
         -- descriptors
         {{ extract_descriptor('v:surveyCategoryDescriptor::string') }} as survey_category,

--- a/models/staging/edfi_3/stage/_edfi_3__stage.yml
+++ b/models/staging/edfi_3/stage/_edfi_3__stage.yml
@@ -962,13 +962,16 @@ models:
           *ref_k_survey
 
   - name: stg_ef3__survey_questions
-    config: 
+    config:
       tags: ['survey']
       enabled: "{{ var('src:domain:survey:enabled', True) }}"
     columns:
       - name: k_survey
-        tests: 
+        tests:
           *ref_k_survey
+      - name: k_survey_section
+        tests:
+          *ref_k_survey_section
 
   - name: stg_ef3__survey_question_responses
     config: 

--- a/models/staging/edfi_3/stage/stg_ef3__survey_questions.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__survey_questions.sql
@@ -7,11 +7,13 @@ keyed as (
             [
                 'tenant_code',
                 'api_year',
+                'lower(namespace)',
                 'lower(question_code)',
-                'lower(survey_id)' 
+                'lower(survey_id)'
             ]
         ) }} as k_survey_question,
         {{ gen_skey('k_survey') }},
+        {{ gen_skey('k_survey_section') }},
         base_survey_questions.*
         {{ extract_extension(model_name=this.name, flatten=True) }}
     from base_survey_questions

--- a/models/staging/edfi_3/stage/stg_ef3__survey_responses.sql
+++ b/models/staging/edfi_3/stage/stg_ef3__survey_responses.sql
@@ -7,6 +7,7 @@ keyed as (
             [
                 'tenant_code',
                 'api_year',
+                'lower(namespace)',
                 'lower(survey_id)',
                 'lower(survey_response_id)'
             ]


### PR DESCRIPTION
This PR addresses the following:
- `namespace` was missing from some survey keys.
- some `sessionReference` keys were cased incorrectly